### PR TITLE
feat(benchmark): add Phoenix LLM observability integration

### DIFF
--- a/benchmark/locomo/locomo10/main.py
+++ b/benchmark/locomo/locomo10/main.py
@@ -31,6 +31,7 @@ from shared.ultrathink_client import UltrathinkClient, RetrievalResult
 from shared.logging_system import BenchmarkLogger, CallType, init_logger, get_logger
 from shared.llm_call_tracker import LLMCallTracker
 from shared.config import get_deepseek_api_key, DEEPSEEK_BASE_URL, DEEPSEEK_MODEL
+from shared.phoenix_tracer import PhoenixTracer
 from locomo10.metrics_tracker import FRMetricsTracker, TokenMetrics
 from locomo10.progress_display import FRProgressDisplay
 from locomo10.f1_evaluator import F1Evaluator, get_category_name, get_category_display
@@ -57,7 +58,8 @@ class FreeResponseExperiment:
         enable_logging: bool = True,
         log_dir: str = "logs",
         random_sample: bool = False,
-        seed: Optional[int] = None
+        seed: Optional[int] = None,
+        enable_phoenix: bool = False
     ):
         """
         Initialize free-response experiment.
@@ -70,6 +72,7 @@ class FreeResponseExperiment:
             log_dir: Directory for log files
             random_sample: If True, randomly sample questions instead of taking first N
             seed: Random seed for reproducible sampling (None = random)
+            enable_phoenix: Enable Phoenix tracing UI (localhost:6006)
         """
         self.dataset_path = dataset_path
         self.max_questions = max_questions
@@ -87,6 +90,9 @@ class FreeResponseExperiment:
             )
         else:
             self.logger = None
+
+        # Initialize Phoenix tracer for LLM observability
+        self.phoenix = PhoenixTracer(enabled=enable_phoenix, launch_ui=enable_phoenix)
 
         # Initialize clients
         self.memory_client = UltrathinkClient(base_url=ultrathink_url)
@@ -241,6 +247,18 @@ class FreeResponseExperiment:
 
         return messages
 
+    def _calculate_cost(self, token_metrics: TokenMetrics) -> float:
+        """
+        Calculate cost in USD for DeepSeek API call.
+
+        DeepSeek-chat pricing (as of 2024):
+        - Input: $0.14 per 1M tokens
+        - Output: $0.28 per 1M tokens
+        """
+        input_cost = token_metrics.input_tokens * 0.14 / 1_000_000
+        output_cost = token_metrics.output_tokens * 0.28 / 1_000_000
+        return input_cost + output_cost
+
     def _generate_answer(
         self,
         question: str,
@@ -328,6 +346,11 @@ Provide a concise, direct answer. Do not explain your reasoning."""
             ultrathink_url=self.ultrathink_url
         )
 
+        # Launch Phoenix UI if enabled
+        phoenix_url = self.phoenix.launch_ui()
+        if phoenix_url:
+            print(f"Phoenix UI: {phoenix_url}")
+
         # Log benchmark start
         if self.logger:
             self.logger.log_benchmark_event(
@@ -359,7 +382,17 @@ Provide a concise, direct answer. Do not explain your reasoning."""
         last_conv_id = None
         cached_memory_ids = []
 
-        for idx, question_data in enumerate(self.questions):
+        # Wrap entire benchmark in Phoenix trace
+        with self.phoenix.trace(
+            name="locomo10-benchmark",
+            metadata={
+                "total_questions": len(self.questions),
+                "dataset": self.dataset_path,
+                "ultrathink_url": self.ultrathink_url,
+            }
+        ) as benchmark_ctx:
+
+          for idx, question_data in enumerate(self.questions):
             q_id = question_data["question_id"]
             conv_id = question_data["conversation_id"]
             category = question_data["category"]
@@ -385,172 +418,216 @@ Provide a concise, direct answer. Do not explain your reasoning."""
                     }
                 )
 
-            # Step 1: Ingest conversation as memories (cache by conversation)
-            session_id = f"locomo-fr-{conv_id}"
+            # Wrap each question in Phoenix span for detailed tracing
+            with self.phoenix.span(
+                benchmark_ctx,
+                name=f"question-{idx+1}",
+                metadata={
+                    "question_id": q_id,
+                    "category": category,
+                    "category_name": get_category_name(category),
+                }
+            ) as question_ctx:
 
-            if conv_id != last_conv_id:
-                # Clear previous session if exists
-                if last_conv_id is not None:
-                    prev_session_id = f"locomo-fr-{last_conv_id}"
-                    self.memory_client.clear_session(prev_session_id)
+                # Step 1: Ingest conversation as memories (cache by conversation)
+                session_id = f"locomo-fr-{conv_id}"
 
-                # Ingest new conversation
-                messages = self._flatten_conversation(question_data["conversation"])
-                ingest_start = time.time()
-                cached_memory_ids, ingest_time = self.memory_client.ingest_conversation(
-                    messages=messages,
-                    session_id=session_id,
-                    domain="locomo-fr-benchmark"
+                if conv_id != last_conv_id:
+                    # Clear previous session if exists
+                    if last_conv_id is not None:
+                        prev_session_id = f"locomo-fr-{last_conv_id}"
+                        self.memory_client.clear_session(prev_session_id)
+
+                    # Ingest new conversation
+                    messages = self._flatten_conversation(question_data["conversation"])
+                    ingest_start = time.time()
+                    cached_memory_ids, ingest_time = self.memory_client.ingest_conversation(
+                        messages=messages,
+                        session_id=session_id,
+                        domain="locomo-fr-benchmark"
+                    )
+                    last_conv_id = conv_id
+
+                    # Log memory ingest
+                    if self.logger:
+                        self.logger.log_memory_call(
+                            call_type=CallType.MEMORY_INGEST,
+                            operation="ingest_conversation",
+                            duration_ms=ingest_time * 1000,
+                            num_items=len(cached_memory_ids),
+                            status="success",
+                            metadata={
+                                "question_id": q_id,
+                                "session_id": session_id,
+                                "num_messages": len(messages)
+                            }
+                        )
+                else:
+                    # Use cached conversation
+                    ingest_time = 0.0
+
+                # Step 2: Retrieve relevant memories
+                retrieve_start = time.time()
+                retrieved_results, retrieval_time = self.memory_client.retrieve_memories(
+                    query=question_data["question"],
+                    top_k=10,
+                    use_ai=True,
+                    min_similarity=0.0
                 )
-                last_conv_id = conv_id
 
-                # Log memory ingest
+                # Log retrieval to Phoenix
+                self.phoenix.log_retrieval(
+                    question_ctx,
+                    query=question_data["question"],
+                    num_results=len(retrieved_results),
+                    latency_ms=retrieval_time * 1000
+                )
+
+                # Display memory operations
+                progress.display_memory_ops(
+                    num_ingested=len(cached_memory_ids),
+                    ingest_time=ingest_time,
+                    num_retrieved=len(retrieved_results),
+                    retrieval_time=retrieval_time
+                )
+
+                # Log memory retrieval
                 if self.logger:
                     self.logger.log_memory_call(
-                        call_type=CallType.MEMORY_INGEST,
-                        operation="ingest_conversation",
-                        duration_ms=ingest_time * 1000,
-                        num_items=len(cached_memory_ids),
+                        call_type=CallType.MEMORY_RETRIEVE,
+                        operation="retrieve_memories",
+                        duration_ms=retrieval_time * 1000,
+                        num_items=len(retrieved_results),
                         status="success",
                         metadata={
                             "question_id": q_id,
-                            "session_id": session_id,
-                            "num_messages": len(messages)
+                            "query_preview": question_data["question"][:100],
+                            "top_k": 10,
+                            "use_ai": True
                         }
                     )
-            else:
-                # Use cached conversation
-                ingest_time = 0.0
 
-            # Step 2: Retrieve relevant memories
-            retrieve_start = time.time()
-            retrieved_results, retrieval_time = self.memory_client.retrieve_memories(
-                query=question_data["question"],
-                top_k=10,
-                use_ai=True,
-                min_similarity=0.0
-            )
+                # Step 3: Format retrieved context
+                retrieved_context = self.memory_client.format_retrieved_as_context(retrieved_results)
+                retrieved_tokens = len(retrieved_context.split())
 
-            # Display memory operations
-            progress.display_memory_ops(
-                num_ingested=len(cached_memory_ids),
-                ingest_time=ingest_time,
-                num_retrieved=len(retrieved_results),
-                retrieval_time=retrieval_time
-            )
-
-            # Log memory retrieval
-            if self.logger:
-                self.logger.log_memory_call(
-                    call_type=CallType.MEMORY_RETRIEVE,
-                    operation="retrieve_memories",
-                    duration_ms=retrieval_time * 1000,
-                    num_items=len(retrieved_results),
-                    status="success",
-                    metadata={
-                        "question_id": q_id,
-                        "query_preview": question_data["question"][:100],
-                        "top_k": 10,
-                        "use_ai": True
-                    }
+                # Step 4: Generate FREE-TEXT answer
+                prediction, token_metrics, llm_latency = self._generate_answer(
+                    question=question_data["question"],
+                    context=retrieved_context,
+                    category=category
                 )
 
-            # Step 3: Format retrieved context
-            retrieved_context = self.memory_client.format_retrieved_as_context(retrieved_results)
-            retrieved_tokens = len(retrieved_context.split())
+                # Log LLM call to Phoenix
+                self.phoenix.log_llm_call(
+                    question_ctx,
+                    model=DEEPSEEK_MODEL,
+                    prompt=f"Q: {question_data['question']}\nContext: {retrieved_context[:500]}...",
+                    response=prediction,
+                    input_tokens=token_metrics.input_tokens,
+                    output_tokens=token_metrics.output_tokens,
+                    latency_ms=llm_latency * 1000,
+                    cost_usd=self._calculate_cost(token_metrics)
+                )
 
-            # Step 4: Generate FREE-TEXT answer
-            prediction, token_metrics, llm_latency = self._generate_answer(
-                question=question_data["question"],
-                context=retrieved_context,
-                category=category
-            )
+                # Step 5: Evaluate with F1 score
+                ground_truth = question_data["answer"]
+                eval_result = self.evaluator.evaluate(
+                    prediction=prediction,
+                    ground_truth=ground_truth,
+                    category=category
+                )
+                f1_score = eval_result["f1_score"]
 
-            # Step 5: Evaluate with F1 score
-            ground_truth = question_data["answer"]
-            eval_result = self.evaluator.evaluate(
-                prediction=prediction,
-                ground_truth=ground_truth,
-                category=category
-            )
-            f1_score = eval_result["f1_score"]
+                # Log evals to Phoenix
+                self.phoenix.log_eval(
+                    question_ctx,
+                    name="f1_score",
+                    value=f1_score,
+                    comment=get_category_name(category)
+                )
+                self.phoenix.log_eval(
+                    question_ctx,
+                    name="accuracy",
+                    value=1.0 if f1_score >= 0.5 else 0.0
+                )
 
-            # Display result with F1 score
-            progress.display_result(
-                prediction=prediction,
-                ground_truth=ground_truth,
-                f1_score=f1_score,
-                llm_latency=llm_latency,
-                input_tokens=token_metrics.input_tokens,
-                output_tokens=token_metrics.output_tokens,
-                category=category
-            )
+                # Display result with F1 score
+                progress.display_result(
+                    prediction=prediction,
+                    ground_truth=ground_truth,
+                    f1_score=f1_score,
+                    llm_latency=llm_latency,
+                    input_tokens=token_metrics.input_tokens,
+                    output_tokens=token_metrics.output_tokens,
+                    category=category
+                )
 
-            # Step 6: Track metrics
-            baseline_tokens = 20000  # Approximate for full conversation
-            total_latency = retrieval_time + llm_latency  # End-to-end latency
+                # Step 6: Track metrics
+                baseline_tokens = 20000  # Approximate for full conversation
+                total_latency = retrieval_time + llm_latency  # End-to-end latency
 
-            # Record in metrics tracker
-            self.metrics_tracker.add_result(
-                question_id=q_id,
-                question_text=question_data["question"],
-                category=category,
-                ground_truth=ground_truth,
-                prediction=prediction,
-                f1_score=f1_score,
-                evaluation_method=eval_result["evaluation_method"],
-                latency=total_latency,  # End-to-end for backwards compatibility
-                tokens=token_metrics,
-                llm_response_time=llm_latency,
-                context_building_time=retrieval_time,
-                memory_retrieval_latency=retrieval_time,  # Key metric for ultrathink performance
-                end_to_end_latency=total_latency,  # Retrieval + LLM
-            )
+                # Record in metrics tracker
+                self.metrics_tracker.add_result(
+                    question_id=q_id,
+                    question_text=question_data["question"],
+                    category=category,
+                    ground_truth=ground_truth,
+                    prediction=prediction,
+                    f1_score=f1_score,
+                    evaluation_method=eval_result["evaluation_method"],
+                    latency=total_latency,  # End-to-end for backwards compatibility
+                    tokens=token_metrics,
+                    llm_response_time=llm_latency,
+                    context_building_time=retrieval_time,
+                    memory_retrieval_latency=retrieval_time,  # Key metric for ultrathink performance
+                    end_to_end_latency=total_latency,  # Retrieval + LLM
+                )
 
-            # Store raw result
-            result = {
-                "question_id": q_id,
-                "conversation_id": conv_id,
-                "question": question_data["question"],
-                "ground_truth": ground_truth,
-                "prediction": prediction,
-                "f1_score": f1_score,
-                "evaluation_method": eval_result["evaluation_method"],
-                "category": category,
-                "category_name": get_category_name(category),
-                "latency_total": retrieval_time + llm_latency,
-                "latency_context_building": retrieval_time,
-                "latency_llm_response": llm_latency,
-                "tokens": {
-                    "input_tokens": token_metrics.input_tokens,
-                    "output_tokens": token_metrics.output_tokens,
-                    "total_tokens": token_metrics.total_tokens
-                },
-                "retrieval_metadata": {
-                    "tokens_baseline": baseline_tokens,
-                    "tokens_retrieved": retrieved_tokens,
-                    "token_reduction_pct": (baseline_tokens - retrieved_tokens) / baseline_tokens * 100 if baseline_tokens > 0 else 0,
-                    "num_memories_retrieved": len(retrieved_results),
-                    "retrieval_latency": retrieval_time,
-                    "session_id": session_id
+                # Store raw result
+                result = {
+                    "question_id": q_id,
+                    "conversation_id": conv_id,
+                    "question": question_data["question"],
+                    "ground_truth": ground_truth,
+                    "prediction": prediction,
+                    "f1_score": f1_score,
+                    "evaluation_method": eval_result["evaluation_method"],
+                    "category": category,
+                    "category_name": get_category_name(category),
+                    "latency_total": retrieval_time + llm_latency,
+                    "latency_context_building": retrieval_time,
+                    "latency_llm_response": llm_latency,
+                    "tokens": {
+                        "input_tokens": token_metrics.input_tokens,
+                        "output_tokens": token_metrics.output_tokens,
+                        "total_tokens": token_metrics.total_tokens
+                    },
+                    "retrieval_metadata": {
+                        "tokens_baseline": baseline_tokens,
+                        "tokens_retrieved": retrieved_tokens,
+                        "token_reduction_pct": (baseline_tokens - retrieved_tokens) / baseline_tokens * 100 if baseline_tokens > 0 else 0,
+                        "num_memories_retrieved": len(retrieved_results),
+                        "retrieval_latency": retrieval_time,
+                        "session_id": session_id
+                    }
                 }
-            }
 
-            results[q_id] = result
+                results[q_id] = result
 
-            # Log question end
-            if self.logger:
-                self.logger.log_benchmark_event(
-                    CallType.QUESTION_END,
-                    f"Question {idx+1} completed",
-                    {
-                        "question_id": q_id,
-                        "f1_score": f1_score,
-                        "category": category,
-                        "tokens_used": token_metrics.total_tokens,
-                        "total_latency": retrieval_time + llm_latency
-                    }
-                )
+                # Log question end
+                if self.logger:
+                    self.logger.log_benchmark_event(
+                        CallType.QUESTION_END,
+                        f"Question {idx+1} completed",
+                        {
+                            "question_id": q_id,
+                            "f1_score": f1_score,
+                            "category": category,
+                            "tokens_used": token_metrics.total_tokens,
+                            "total_latency": retrieval_time + llm_latency
+                        }
+                    )
 
         # Cleanup final session
         if last_conv_id is not None:
@@ -657,6 +734,12 @@ def main():
         default=None,
         help="Random seed for reproducible sampling"
     )
+    parser.add_argument(
+        "--phoenix",
+        action="store_true",
+        default=False,
+        help="Enable Phoenix tracing UI (opens localhost:6006)"
+    )
 
     args = parser.parse_args()
 
@@ -668,7 +751,8 @@ def main():
         enable_logging=args.enable_logging,
         log_dir=args.log_dir,
         random_sample=args.random_sample,
-        seed=args.seed
+        seed=args.seed,
+        enable_phoenix=args.phoenix
     )
 
     experiment.run(output_path=args.output)

--- a/benchmark/locomo/requirements.txt
+++ b/benchmark/locomo/requirements.txt
@@ -10,3 +10,8 @@ python-dotenv>=1.0.0
 # Bridge server
 fastapi>=0.109.0
 uvicorn>=0.27.0
+# Phoenix observability (local-first LLM tracing)
+arize-phoenix>=4.0.0
+opentelemetry-api>=1.0.0
+opentelemetry-sdk>=1.0.0
+openinference-instrumentation>=0.1.0

--- a/benchmark/locomo/shared/phoenix_tracer.py
+++ b/benchmark/locomo/shared/phoenix_tracer.py
@@ -1,0 +1,316 @@
+"""
+Phoenix (Arize) integration for ultrathink benchmarks.
+Local-first LLM observability with web UI.
+
+Phoenix provides:
+- Trace visualization at localhost:6006
+- Latency breakdown (memory retrieval vs LLM)
+- Token analytics
+- Eval score filtering
+- No cloud required, fully local
+
+Usage:
+    tracer = PhoenixTracer(launch_ui=True)
+
+    with tracer.trace("benchmark-run") as ctx:
+        with tracer.span(ctx, "question-1") as q_ctx:
+            tracer.log_retrieval(q_ctx, query="...", num_results=10, latency_ms=50)
+            tracer.log_llm_call(q_ctx, model="deepseek", prompt="...", response="...", ...)
+            tracer.log_eval(q_ctx, "f1_score", 0.85)
+"""
+import os
+import time
+from typing import Dict, Optional, Any
+from contextlib import contextmanager
+from dataclasses import dataclass
+
+# Phoenix imports with graceful fallback
+try:
+    import phoenix as px
+    from opentelemetry import trace as otel_trace
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+    PHOENIX_AVAILABLE = True
+except ImportError:
+    PHOENIX_AVAILABLE = False
+    px = None
+    otel_trace = None
+
+# OpenInference semantic conventions (optional)
+try:
+    from openinference.semconv.trace import SpanAttributes
+    OPENINFERENCE_AVAILABLE = True
+except ImportError:
+    OPENINFERENCE_AVAILABLE = False
+    SpanAttributes = None
+
+
+@dataclass
+class TraceContext:
+    """Context for a trace with spans."""
+    trace_id: Any
+    span: Any
+    start_time: float
+    name: str
+
+
+class PhoenixTracer:
+    """
+    Wrapper for Phoenix tracing with graceful degradation.
+
+    If Phoenix is not installed or disabled, all methods become no-ops.
+    This allows the benchmark to run without Phoenix dependencies.
+    """
+
+    def __init__(self, enabled: bool = True, launch_ui: bool = False):
+        """
+        Initialize Phoenix tracer.
+
+        Args:
+            enabled: Whether to enable tracing (default True)
+            launch_ui: Whether to launch the Phoenix UI on init (default False)
+        """
+        self.enabled = enabled and PHOENIX_AVAILABLE
+        self.session = None
+        self.tracer = None
+        self._initialized = False
+        self._phoenix_url = ""
+
+        if self.enabled and launch_ui:
+            self._initialize(launch_ui=True)
+
+    def _is_phoenix_running(self, port: int = 6006) -> bool:
+        """Check if Phoenix is already running on the given port."""
+        import socket
+        try:
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+                s.settimeout(1)
+                result = s.connect_ex(('localhost', port))
+                return result == 0
+        except Exception:
+            return False
+
+    def _initialize(self, launch_ui: bool = False):
+        """Initialize Phoenix and OpenTelemetry."""
+        if self._initialized:
+            return
+
+        try:
+            if launch_ui:
+                # Check if Phoenix is already running
+                if self._is_phoenix_running():
+                    print("Phoenix already running at http://localhost:6006/")
+                    self._phoenix_url = "http://localhost:6006/"
+                else:
+                    # Launch Phoenix UI in background
+                    self.session = px.launch_app()
+                    self._phoenix_url = str(self.session.url) if self.session else ""
+
+            # Set up OpenTelemetry tracer with Phoenix
+            from phoenix.otel import register
+            tracer_provider = register(project_name="ultrathink-benchmark")
+            self.tracer = otel_trace.get_tracer("ultrathink.benchmark")
+            self._initialized = True
+
+        except Exception as e:
+            print(f"Warning: Failed to initialize Phoenix: {e}")
+            self.enabled = False
+
+    def launch_ui(self) -> str:
+        """
+        Launch Phoenix UI and return URL.
+
+        Returns:
+            URL of Phoenix UI (e.g., "http://localhost:6006") or empty string
+        """
+        if not self.enabled:
+            return ""
+
+        if not self._initialized:
+            self._initialize(launch_ui=True)
+
+        # Return URL from session or cached URL (if Phoenix was already running)
+        if self.session:
+            return str(self.session.url)
+        return self._phoenix_url
+
+    @contextmanager
+    def trace(self, name: str, metadata: Dict = None):
+        """
+        Create a root trace context.
+
+        Args:
+            name: Name of the trace (e.g., "locomo10-benchmark")
+            metadata: Optional metadata dict
+
+        Yields:
+            TraceContext or None if disabled
+        """
+        if not self.enabled:
+            yield None
+            return
+
+        if not self._initialized:
+            self._initialize()
+
+        if not self.tracer:
+            yield None
+            return
+
+        with self.tracer.start_as_current_span(name) as span:
+            # Set metadata as span attributes
+            if metadata:
+                for k, v in metadata.items():
+                    span.set_attribute(f"metadata.{k}", str(v))
+
+            ctx = TraceContext(
+                trace_id=span.get_span_context().trace_id if span.get_span_context() else None,
+                span=span,
+                start_time=time.time(),
+                name=name
+            )
+            try:
+                yield ctx
+            finally:
+                # Record duration
+                duration = time.time() - ctx.start_time
+                span.set_attribute("duration_seconds", duration)
+
+    @contextmanager
+    def span(self, parent_ctx: Optional[TraceContext], name: str, metadata: Dict = None):
+        """
+        Create a child span within a trace.
+
+        Args:
+            parent_ctx: Parent trace context (can be None)
+            name: Name of the span (e.g., "question-1", "memory-retrieval")
+            metadata: Optional metadata dict
+
+        Yields:
+            TraceContext or None if disabled
+        """
+        if not self.enabled or not self.tracer:
+            yield None
+            return
+
+        with self.tracer.start_as_current_span(name) as span:
+            if metadata:
+                for k, v in metadata.items():
+                    span.set_attribute(f"metadata.{k}", str(v))
+
+            ctx = TraceContext(
+                trace_id=parent_ctx.trace_id if parent_ctx else None,
+                span=span,
+                start_time=time.time(),
+                name=name
+            )
+            try:
+                yield ctx
+            finally:
+                duration = time.time() - ctx.start_time
+                span.set_attribute("duration_seconds", duration)
+
+    def log_retrieval(self, ctx: Optional[TraceContext], query: str,
+                      num_results: int, latency_ms: float):
+        """
+        Log a memory retrieval operation.
+
+        Args:
+            ctx: Trace context
+            query: Search query
+            num_results: Number of results retrieved
+            latency_ms: Retrieval latency in milliseconds
+        """
+        if not self.enabled or not ctx or not ctx.span:
+            return
+
+        # Use OpenInference semantic conventions if available
+        if OPENINFERENCE_AVAILABLE and SpanAttributes:
+            ctx.span.set_attribute(SpanAttributes.INPUT_VALUE, query)
+        else:
+            ctx.span.set_attribute("retrieval.query", query)
+
+        ctx.span.set_attribute("retrieval.num_results", num_results)
+        ctx.span.set_attribute("retrieval.latency_ms", latency_ms)
+
+    def log_llm_call(self, ctx: Optional[TraceContext], model: str, prompt: str,
+                     response: str, input_tokens: int, output_tokens: int,
+                     latency_ms: float, cost_usd: float = 0.0):
+        """
+        Log an LLM generation.
+
+        Args:
+            ctx: Trace context
+            model: Model name (e.g., "deepseek-chat")
+            prompt: Input prompt (truncated for storage)
+            response: LLM response (truncated for storage)
+            input_tokens: Number of input tokens
+            output_tokens: Number of output tokens
+            latency_ms: LLM latency in milliseconds
+            cost_usd: Estimated cost in USD
+        """
+        if not self.enabled or not ctx or not ctx.span:
+            return
+
+        # Use OpenInference semantic conventions if available
+        if OPENINFERENCE_AVAILABLE and SpanAttributes:
+            ctx.span.set_attribute(SpanAttributes.LLM_MODEL_NAME, model)
+            ctx.span.set_attribute(SpanAttributes.INPUT_VALUE, prompt[:2000])
+            ctx.span.set_attribute(SpanAttributes.OUTPUT_VALUE, response[:2000])
+            ctx.span.set_attribute(SpanAttributes.LLM_TOKEN_COUNT_PROMPT, input_tokens)
+            ctx.span.set_attribute(SpanAttributes.LLM_TOKEN_COUNT_COMPLETION, output_tokens)
+        else:
+            ctx.span.set_attribute("llm.model", model)
+            ctx.span.set_attribute("llm.prompt", prompt[:2000])
+            ctx.span.set_attribute("llm.response", response[:2000])
+            ctx.span.set_attribute("llm.input_tokens", input_tokens)
+            ctx.span.set_attribute("llm.output_tokens", output_tokens)
+
+        ctx.span.set_attribute("llm.latency_ms", latency_ms)
+        ctx.span.set_attribute("llm.cost_usd", cost_usd)
+        ctx.span.set_attribute("llm.total_tokens", input_tokens + output_tokens)
+
+    def log_eval(self, ctx: Optional[TraceContext], name: str, value: float,
+                 comment: str = None):
+        """
+        Log an evaluation score.
+
+        Args:
+            ctx: Trace context
+            name: Eval name (e.g., "f1_score", "accuracy")
+            value: Eval value (0.0 to 1.0)
+            comment: Optional comment
+        """
+        if not self.enabled or not ctx or not ctx.span:
+            return
+
+        ctx.span.set_attribute(f"eval.{name}", value)
+        if comment:
+            ctx.span.set_attribute(f"eval.{name}.comment", comment)
+
+    def log_error(self, ctx: Optional[TraceContext], error: str, error_type: str = None):
+        """
+        Log an error.
+
+        Args:
+            ctx: Trace context
+            error: Error message
+            error_type: Optional error type/category
+        """
+        if not self.enabled or not ctx or not ctx.span:
+            return
+
+        ctx.span.set_attribute("error", True)
+        ctx.span.set_attribute("error.message", error[:1000])
+        if error_type:
+            ctx.span.set_attribute("error.type", error_type)
+
+    def close(self):
+        """Cleanup resources."""
+        # Phoenix handles cleanup automatically
+        pass
+
+    @property
+    def is_available(self) -> bool:
+        """Check if Phoenix is available and enabled."""
+        return self.enabled and PHOENIX_AVAILABLE


### PR DESCRIPTION
## Summary
- Add local-first LLM tracing with Phoenix by Arize for benchmark runs
- New `--phoenix` CLI flag for both locomo10 and locomo_mc10 benchmarks
- Traces include: memory retrieval latency, LLM calls, F1/accuracy evals
- Web UI at localhost:6006 for trace visualization and filtering

## Changes
- `shared/phoenix_tracer.py` - New Phoenix wrapper with graceful degradation
- `locomo10/main.py` - Added Phoenix integration + CLI flag
- `locomo_mc10/main.py` - Added Phoenix integration + CLI flag
- `requirements.txt` - Added arize-phoenix, opentelemetry dependencies

## Usage
```bash
# Start benchmark with Phoenix UI
python3 -m locomo10.main --phoenix --max-questions 20

# Open http://localhost:6006/ to view traces
```

## Test plan
- [x] Run locomo10 benchmark with --phoenix flag
- [x] Verify traces appear in Phoenix UI
- [x] Confirm graceful degradation when Phoenix not installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)