### PR TITLE
fix(npm): Update version to 1.2.1 for working binary downloads

### DIFF
--- a/bin/ultrathink
+++ b/bin/ultrathink
@@ -8,7 +8,7 @@ const https = require('https');
 const http = require('http');
 const { URL } = require('url');
 
-const VERSION = '1.2.0';
+const VERSION = '1.2.1';
 const GITHUB_OWNER = 'MycelicMemory';
 const GITHUB_REPO = 'ultrathink';
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mycelic-memory",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "AI-powered persistent memory system for Claude and other AI agents",
   "keywords": [
     "mcp",


### PR DESCRIPTION
## Summary

- Updates `package.json` version from `1.2.0` to `1.2.1`
- Updates `bin/ultrathink` VERSION constant to `1.2.1`

## Problem

The v1.2.0 release did not contain platform binaries. When users ran:
```bash
npm install -g github:MycelicMemory/ultrathink
```

The install would fail because the wrapper script tried to download binaries from `v1.2.0` which returned 404 errors.

## Solution

Updated the npm package version to `1.2.1` which has all platform binaries:
- ✅ ultrathink-macos-arm64
- ✅ ultrathink-macos-x64
- ✅ ultrathink-linux-x64
- ✅ ultrathink-linux-arm64
- ✅ ultrathink-windows-x64.exe

## Test plan

- [ ] Run `npm install -g github:MycelicMemory/ultrathink` on a fresh machine
- [ ] Verify `ultrathink --version` works
- [ ] Verify `ultrathink doctor` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)