### PR TITLE
feat: schema generalization v4→v5 — source-agnostic table names

### DIFF
--- a/desktop/src/renderer/pages/KnowledgeGraph.tsx
+++ b/desktop/src/renderer/pages/KnowledgeGraph.tsx
@@ -197,8 +197,8 @@ export default function KnowledgeGraph() {
       // Find which sessions are referenced by memories
       const referencedSessionIds = new Set(
         filteredMemories
-          .filter((m) => m.cc_session_id)
-          .map((m) => m.cc_session_id!)
+          .filter((m) => m.conversation_id)
+          .map((m) => m.conversation_id!)
       );
 
       // Build a project color map
@@ -252,11 +252,11 @@ export default function KnowledgeGraph() {
     // Build session-to-memory edges (dashed orange)
     if (showSessions) {
       filteredMemories.forEach((memory) => {
-        if (memory.cc_session_id && sessionNodeMap.has(memory.cc_session_id)) {
+        if (memory.conversation_id && sessionNodeMap.has(memory.conversation_id)) {
           edges.push({
             id: `trace:${memory.id}`,
             from: memory.id,
-            to: `session:${memory.cc_session_id}`,
+            to: `session:${memory.conversation_id}`,
             color: { color: SOURCE_EDGE_COLOR },
             width: 1.5,
             arrows: 'to',
@@ -371,9 +371,9 @@ export default function KnowledgeGraph() {
 
   const domains = [...new Set(memories.map((m) => m.domain || 'general'))];
   const relationshipTypes = [...new Set(relationships.map((r) => r.relationship_type))];
-  const linkedCount = memories.filter((m) => m.cc_session_id).length;
+  const linkedCount = memories.filter((m) => m.conversation_id).length;
   const sessionNodeCount = showSessions
-    ? new Set(memories.filter((m) => m.cc_session_id).map((m) => m.cc_session_id)).size
+    ? new Set(memories.filter((m) => m.conversation_id).map((m) => m.conversation_id)).size
     : 0;
 
   return (
@@ -534,8 +534,8 @@ export default function KnowledgeGraph() {
 }
 
 function MemoryDetailPanel({ memory, sessions }: { memory: Memory; sessions: ClaudeSession[] }) {
-  const linkedSession = memory.cc_session_id
-    ? sessions.find((s) => s.id === memory.cc_session_id)
+  const linkedSession = memory.conversation_id
+    ? sessions.find((s) => s.id === memory.conversation_id)
     : null;
 
   return (

--- a/desktop/src/shared/types.ts
+++ b/desktop/src/shared/types.ts
@@ -13,7 +13,7 @@ export interface Memory {
   created_at: string;
   updated_at: string;
   session_id?: string;
-  cc_session_id?: string;
+  conversation_id?: string;
 }
 
 export interface MemoryCreateInput {

--- a/internal/api/handlers_chat.go
+++ b/internal/api/handlers_chat.go
@@ -289,7 +289,7 @@ func (s *Server) traceMemorySource(c *gin.Context) {
 		return
 	}
 
-	if mem.CCSessionID == "" {
+	if mem.ConversationID == "" {
 		c.JSON(http.StatusOK, gin.H{
 			"success":    true,
 			"has_source": false,
@@ -298,17 +298,17 @@ func (s *Server) traceMemorySource(c *gin.Context) {
 		return
 	}
 
-	sess, err := s.db.GetCCSession(mem.CCSessionID)
+	sess, err := s.db.GetCCSession(mem.ConversationID)
 	if err != nil {
 		c.JSON(http.StatusOK, gin.H{
 			"success":    true,
 			"has_source": false,
-			"message":    "Linked session not found",
+			"message":    "Linked conversation not found",
 		})
 		return
 	}
 
-	messages, _ := s.db.GetCCMessages(mem.CCSessionID, 20, 0)
+	messages, _ := s.db.GetCCMessages(mem.ConversationID, 20, 0)
 
 	c.JSON(http.StatusOK, gin.H{
 		"success":    true,

--- a/internal/api/handlers_memory.go
+++ b/internal/api/handlers_memory.go
@@ -28,7 +28,7 @@ type MemoryData struct {
 	Domain      *string   `json:"domain"`
 	CreatedAt   time.Time `json:"created_at"`
 	UpdatedAt   time.Time `json:"updated_at"`
-	CCSessionID *string   `json:"cc_session_id,omitempty"`
+	ConversationID *string `json:"conversation_id,omitempty"`
 }
 
 // CreateMemoryRequest represents a memory creation request
@@ -71,8 +71,8 @@ func toMemoryData(m *database.Memory) *MemoryData {
 	if m.Domain != "" {
 		data.Domain = &m.Domain
 	}
-	if m.CCSessionID != "" {
-		data.CCSessionID = &m.CCSessionID
+	if m.ConversationID != "" {
+		data.ConversationID = &m.ConversationID
 	}
 
 	// Ensure tags is not nil

--- a/internal/claude/ingestion.go
+++ b/internal/claude/ingestion.go
@@ -360,7 +360,7 @@ func (ing *Ingester) createSummaryMemory(ctx context.Context, session *database.
 		UpdatedAt:   time.Now(),
 		AgentType:   "claude-code",
 		AccessScope: "session",
-		CCSessionID: session.ID,
+		ConversationID: session.ID,
 	}
 
 	// We need to set tags JSON for the DB insert

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -98,11 +98,11 @@ func (d *Database) InitSchema() error {
 		return fmt.Errorf("failed to create core schema: %w", err)
 	}
 
-	// Execute chat history schema (cc_sessions, cc_messages, cc_tool_calls)
-	log.Debug("creating chat history schema")
-	if _, err := tx.Exec(ChatHistorySchema); err != nil {
-		log.Error("failed to create chat history schema", "error", err)
-		return fmt.Errorf("failed to create chat history schema: %w", err)
+	// Execute conversation schema (conversations, messages, actions)
+	log.Debug("creating conversation schema")
+	if _, err := tx.Exec(ConversationSchema); err != nil {
+		log.Error("failed to create conversation schema", "error", err)
+		return fmt.Errorf("failed to create conversation schema: %w", err)
 	}
 
 	// Execute FTS5 schema (virtual table, triggers)

--- a/internal/database/migrations.go
+++ b/internal/database/migrations.go
@@ -169,6 +169,13 @@ func (d *Database) RunMigrations() error {
 		}
 	}
 
+	// Generalize cc_* tables to source-agnostic names
+	if version < 5 {
+		if err := MigrationV4ToV5(d.db); err != nil {
+			return fmt.Errorf("migration v4 to v5 failed: %w", err)
+		}
+	}
+
 	return nil
 }
 
@@ -272,6 +279,78 @@ func MigrationV2ToV3(db *sql.DB) error {
 	return nil
 }
 
+// MigrationV4ToV5 generalizes cc_* tables to source-agnostic names
+// Renames: cc_sessions → conversations, cc_messages → messages, cc_tool_calls → actions
+// Renames: memories.cc_session_id → memories.conversation_id
+func MigrationV4ToV5(db *sql.DB) error {
+	log.Info("running migration v4 to v5: generalizing table names")
+
+	tx, err := db.Begin()
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck // rollback after commit is harmless
+
+	// 1. Rename tables (SQLite supports ALTER TABLE RENAME TO)
+	renameStatements := []string{
+		"ALTER TABLE cc_sessions RENAME TO conversations;",
+		"ALTER TABLE cc_messages RENAME TO messages;",
+		"ALTER TABLE cc_tool_calls RENAME TO actions;",
+	}
+
+	for _, stmt := range renameStatements {
+		if _, err := tx.Exec(stmt); err != nil {
+			// Table may already be renamed (idempotent)
+			log.Debug("rename skipped (may already exist)", "stmt", stmt, "error", err)
+		}
+	}
+
+	// 2. Rename cc_session_id column on memories table
+	// SQLite 3.25.0+ supports ALTER TABLE RENAME COLUMN
+	if _, err := tx.Exec("ALTER TABLE memories RENAME COLUMN cc_session_id TO conversation_id;"); err != nil {
+		log.Debug("column rename skipped (may already exist)", "error", err)
+	}
+
+	// 3. Create new indexes with updated names (old indexes auto-renamed with table)
+	// The table-level indexes were auto-renamed by SQLite, but let's ensure
+	// the new naming convention indexes exist
+	indexStatements := []string{
+		"CREATE INDEX IF NOT EXISTS idx_conversations_session_id ON conversations(session_id);",
+		"CREATE INDEX IF NOT EXISTS idx_conversations_project ON conversations(project_path);",
+		"CREATE INDEX IF NOT EXISTS idx_conversations_hash ON conversations(project_hash);",
+		"CREATE INDEX IF NOT EXISTS idx_conversations_created ON conversations(created_at);",
+		"CREATE UNIQUE INDEX IF NOT EXISTS idx_conversations_dedup ON conversations(project_hash, session_id);",
+		"CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(session_id);",
+		"CREATE INDEX IF NOT EXISTS idx_messages_role ON messages(role);",
+		"CREATE INDEX IF NOT EXISTS idx_messages_seq ON messages(session_id, sequence_index);",
+		"CREATE INDEX IF NOT EXISTS idx_actions_session ON actions(session_id);",
+		"CREATE INDEX IF NOT EXISTS idx_actions_name ON actions(tool_name);",
+		"CREATE INDEX IF NOT EXISTS idx_actions_filepath ON actions(filepath);",
+		"CREATE INDEX IF NOT EXISTS idx_memories_conversation ON memories(conversation_id);",
+	}
+
+	for _, stmt := range indexStatements {
+		if _, err := tx.Exec(stmt); err != nil {
+			log.Debug("index creation skipped (may already exist)", "stmt", stmt, "error", err)
+		}
+	}
+
+	// 4. Update schema version
+	if _, err := tx.Exec(`
+		INSERT OR REPLACE INTO schema_version (version, applied_at)
+		VALUES (5, CURRENT_TIMESTAMP)
+	`); err != nil {
+		return fmt.Errorf("failed to update schema version: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit migration: %w", err)
+	}
+
+	log.Info("migration v4 to v5 completed successfully")
+	return nil
+}
+
 // MigrationV3ToV4 adds Claude Code chat history tables
 // This creates cc_sessions, cc_messages, cc_tool_calls and links memories to sessions
 func MigrationV3ToV4(db *sql.DB) error {
@@ -283,8 +362,43 @@ func MigrationV3ToV4(db *sql.DB) error {
 	}
 	defer tx.Rollback() //nolint:errcheck // rollback after commit is harmless
 
-	// 1. Create chat history tables
-	if _, err := tx.Exec(ChatHistorySchema); err != nil {
+	// 1. Create chat history tables (using old cc_* names, v5 migration will rename)
+	chatHistorySQL := `
+		CREATE TABLE IF NOT EXISTS cc_sessions (
+			id TEXT PRIMARY KEY, session_id TEXT NOT NULL, project_path TEXT NOT NULL,
+			project_hash TEXT NOT NULL, model TEXT, title TEXT, first_prompt TEXT,
+			summary TEXT, created_at DATETIME NOT NULL, updated_at DATETIME NOT NULL,
+			last_activity DATETIME, message_count INTEGER DEFAULT 0,
+			user_message_count INTEGER DEFAULT 0, assistant_message_count INTEGER DEFAULT 0,
+			tool_call_count INTEGER DEFAULT 0, source_id TEXT, file_path TEXT,
+			last_sync_position TEXT, summary_memory_id TEXT,
+			FOREIGN KEY (source_id) REFERENCES data_sources(id) ON DELETE SET NULL,
+			FOREIGN KEY (summary_memory_id) REFERENCES memories(id) ON DELETE SET NULL
+		);
+		CREATE INDEX IF NOT EXISTS idx_cc_sessions_session_id ON cc_sessions(session_id);
+		CREATE INDEX IF NOT EXISTS idx_cc_sessions_project ON cc_sessions(project_path);
+		CREATE INDEX IF NOT EXISTS idx_cc_sessions_hash ON cc_sessions(project_hash);
+		CREATE INDEX IF NOT EXISTS idx_cc_sessions_created ON cc_sessions(created_at);
+		CREATE UNIQUE INDEX IF NOT EXISTS idx_cc_sessions_dedup ON cc_sessions(project_hash, session_id);
+		CREATE TABLE IF NOT EXISTS cc_messages (
+			id TEXT PRIMARY KEY, session_id TEXT NOT NULL REFERENCES cc_sessions(id) ON DELETE CASCADE,
+			role TEXT NOT NULL, content TEXT, timestamp DATETIME, sequence_index INTEGER NOT NULL,
+			has_tool_use BOOLEAN DEFAULT 0, token_count INTEGER DEFAULT 0
+		);
+		CREATE INDEX IF NOT EXISTS idx_cc_messages_session ON cc_messages(session_id);
+		CREATE INDEX IF NOT EXISTS idx_cc_messages_role ON cc_messages(role);
+		CREATE INDEX IF NOT EXISTS idx_cc_messages_seq ON cc_messages(session_id, sequence_index);
+		CREATE TABLE IF NOT EXISTS cc_tool_calls (
+			id TEXT PRIMARY KEY, session_id TEXT NOT NULL REFERENCES cc_sessions(id) ON DELETE CASCADE,
+			message_id TEXT REFERENCES cc_messages(id) ON DELETE CASCADE, tool_name TEXT NOT NULL,
+			input_json TEXT, result_text TEXT, success BOOLEAN DEFAULT 1,
+			filepath TEXT, operation TEXT, timestamp DATETIME
+		);
+		CREATE INDEX IF NOT EXISTS idx_cc_tool_calls_session ON cc_tool_calls(session_id);
+		CREATE INDEX IF NOT EXISTS idx_cc_tool_calls_name ON cc_tool_calls(tool_name);
+		CREATE INDEX IF NOT EXISTS idx_cc_tool_calls_filepath ON cc_tool_calls(filepath);
+	`
+	if _, err := tx.Exec(chatHistorySQL); err != nil {
 		return fmt.Errorf("failed to create chat history tables: %w", err)
 	}
 

--- a/internal/database/models.go
+++ b/internal/database/models.go
@@ -29,8 +29,8 @@ type Memory struct {
 	// Multi-source ingestion fields (Schema v3)
 	SourceID   string `json:"source_id,omitempty"`   // Reference to data_sources.id
 	ExternalID string `json:"external_id,omitempty"` // Unique ID in source system (for deduplication)
-	// Chat history linkage (Schema v4)
-	CCSessionID string `json:"cc_session_id,omitempty"` // Reference to cc_sessions.id
+	// Conversation linkage (Schema v5)
+	ConversationID string `json:"conversation_id,omitempty"` // Reference to conversations.id
 }
 
 // IsChunk returns true if this memory is a chunk (not a root memory)
@@ -321,18 +321,18 @@ type DataSourceUpdate struct {
 }
 
 // =============================================================================
-// CHAT HISTORY MODELS (Schema v4)
+// CONVERSATION MODELS (Schema v5, generalized from cc_* types)
 // =============================================================================
 
-// CCSession represents a Claude Code chat session
-type CCSession struct {
+// Conversation represents an ingested conversation from any source
+type Conversation struct {
 	ID                    string     `json:"id"`
-	SessionID             string     `json:"session_id"`              // Claude session UUID from JSONL filename
-	ProjectPath           string     `json:"project_path"`            // e.g. C:\dev\active\ai\MycelicMemory
-	ProjectHash           string     `json:"project_hash"`            // hashed project dir name
-	Model                 string     `json:"model,omitempty"`         // model used
-	Title                 string     `json:"title,omitempty"`         // generated from first user prompt
-	FirstPrompt           string     `json:"first_prompt,omitempty"`  // first user message (truncated)
+	SessionID             string     `json:"session_id"`              // Source session identifier
+	ProjectPath           string     `json:"project_path"`            // Project/workspace/channel context
+	ProjectHash           string     `json:"project_hash"`            // Hashed project/space identifier
+	Model                 string     `json:"model,omitempty"`         // Model used (if applicable)
+	Title                 string     `json:"title,omitempty"`         // Generated title
+	FirstPrompt           string     `json:"first_prompt,omitempty"`  // First user message (truncated)
 	Summary               string     `json:"summary,omitempty"`       // LLM-generated summary
 	CreatedAt             time.Time  `json:"created_at"`
 	UpdatedAt             time.Time  `json:"updated_at"`
@@ -347,11 +347,11 @@ type CCSession struct {
 	SummaryMemoryID       string     `json:"summary_memory_id,omitempty"`
 }
 
-// CCMessage represents a message in a Claude Code chat session
-type CCMessage struct {
+// ConversationMessage represents a message in a conversation
+type ConversationMessage struct {
 	ID            string     `json:"id"`
-	SessionID     string     `json:"session_id"`     // References cc_sessions.id
-	Role          string     `json:"role"`            // 'user', 'assistant', 'system'
+	SessionID     string     `json:"session_id"`     // References conversations.id
+	Role          string     `json:"role"`            // 'user', 'assistant', 'bot', 'system'
 	Content       string     `json:"content"`
 	Timestamp     *time.Time `json:"timestamp,omitempty"`
 	SequenceIndex int        `json:"sequence_index"`
@@ -359,30 +359,30 @@ type CCMessage struct {
 	TokenCount    int        `json:"token_count"`
 }
 
-// CCToolCall represents a tool call in a Claude Code chat session
-type CCToolCall struct {
+// ConversationAction represents a tool call, reaction, or other action
+type ConversationAction struct {
 	ID         string     `json:"id"`
-	SessionID  string     `json:"session_id"`  // References cc_sessions.id
-	MessageID  string     `json:"message_id"`  // References cc_messages.id
+	SessionID  string     `json:"session_id"`  // References conversations.id
+	MessageID  string     `json:"message_id"`  // References messages.id
 	ToolName   string     `json:"tool_name"`
 	InputJSON  string     `json:"input_json,omitempty"`
 	ResultText string     `json:"result_text,omitempty"`
 	Success    bool       `json:"success"`
 	FilePath   string     `json:"filepath,omitempty"`
-	Operation  string     `json:"operation,omitempty"` // 'read', 'write', 'edit', 'execute'
+	Operation  string     `json:"operation,omitempty"` // 'read', 'write', 'edit', 'execute', 'reaction'
 	Timestamp  *time.Time `json:"timestamp,omitempty"`
 }
 
-// CCSessionFilters represents filters for listing chat sessions
-type CCSessionFilters struct {
+// ConversationFilters represents filters for listing conversations
+type ConversationFilters struct {
 	ProjectPath string `json:"project_path,omitempty"`
 	MinMessages int    `json:"min_messages,omitempty"`
 	Limit       int    `json:"limit,omitempty"`
 	Offset      int    `json:"offset,omitempty"`
 }
 
-// CCSessionUpdate represents optional updates to a chat session
-type CCSessionUpdate struct {
+// ConversationUpdate represents optional updates to a conversation
+type ConversationUpdate struct {
 	Title            *string `json:"title,omitempty"`
 	Summary          *string `json:"summary,omitempty"`
 	MessageCount     *int    `json:"message_count,omitempty"`
@@ -392,4 +392,11 @@ type CCSessionUpdate struct {
 	LastSyncPosition *string `json:"last_sync_position,omitempty"`
 	SummaryMemoryID  *string `json:"summary_memory_id,omitempty"`
 }
+
+// Type aliases for backward compatibility during transition
+type CCSession = Conversation
+type CCMessage = ConversationMessage
+type CCToolCall = ConversationAction
+type CCSessionFilters = ConversationFilters
+type CCSessionUpdate = ConversationUpdate
 

--- a/internal/database/operations.go
+++ b/internal/database/operations.go
@@ -48,7 +48,7 @@ func (d *Database) CreateMemory(m *Memory) error {
 			id, content, source, importance, tags, session_id, domain,
 			embedding, created_at, updated_at, agent_type, agent_context,
 			access_scope, slug, parent_memory_id, chunk_level, chunk_index,
-			cc_session_id
+			conversation_id
 		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`,
 		m.ID, m.Content, nullString(m.Source), m.Importance, tagsJSON,
@@ -56,7 +56,7 @@ func (d *Database) CreateMemory(m *Memory) error {
 		m.Embedding, m.CreatedAt, m.UpdatedAt, m.AgentType, nullString(m.AgentContext),
 		m.AccessScope, nullString(m.Slug),
 		nullString(m.ParentMemoryID), m.ChunkLevel, m.ChunkIndex,
-		nullString(m.CCSessionID),
+		nullString(m.ConversationID),
 	)
 
 	if err != nil {
@@ -83,7 +83,7 @@ func (d *Database) GetMemory(id string) (*Memory, error) {
 		SELECT id, content, source, importance, tags, session_id, domain,
 		       embedding, created_at, updated_at, agent_type, agent_context,
 		       access_scope, slug, parent_memory_id, chunk_level, chunk_index,
-		       cc_session_id
+		       conversation_id
 		FROM memories WHERE id = ?
 	`, id).Scan(
 		&m.ID, &m.Content, &source, &m.Importance, &tagsJSON, &sessionID, &domain,
@@ -106,7 +106,7 @@ func (d *Database) GetMemory(id string) (*Memory, error) {
 	m.AgentContext = agentContext.String
 	m.Slug = slug.String
 	m.ParentMemoryID = parentMemoryID.String
-	m.CCSessionID = ccSessionID.String
+	m.ConversationID = ccSessionID.String
 	m.Embedding = embedding
 	m.Tags = ParseTags(tagsJSON)
 
@@ -244,7 +244,7 @@ func (d *Database) ListMemories(filters *MemoryFilters) ([]*Memory, error) {
 		SELECT id, content, source, importance, tags, session_id, domain,
 		       embedding, created_at, updated_at, agent_type, agent_context,
 		       access_scope, slug, parent_memory_id, chunk_level, chunk_index,
-		       cc_session_id
+		       conversation_id
 		FROM memories
 	`
 
@@ -548,7 +548,7 @@ func (d *Database) FindRelated(memoryID string, filters *RelationshipFilters) ([
 		SELECT DISTINCT m.id, m.content, m.source, m.importance, m.tags, m.session_id, m.domain,
 		       m.embedding, m.created_at, m.updated_at, m.agent_type, m.agent_context,
 		       m.access_scope, m.slug, m.parent_memory_id, m.chunk_level, m.chunk_index,
-		       m.cc_session_id
+		       m.conversation_id
 		FROM memories m
 		JOIN memory_relationships r ON (
 			(r.source_memory_id = ? AND r.target_memory_id = m.id) OR
@@ -796,7 +796,7 @@ func (d *Database) GetMemoriesByIDs(ids []string) ([]*Memory, error) {
 		SELECT id, content, source, importance, tags, session_id, domain,
 		       embedding, created_at, updated_at, agent_type, agent_context,
 		       access_scope, slug, parent_memory_id, chunk_level, chunk_index,
-		       cc_session_id
+		       conversation_id
 		FROM memories
 		WHERE id IN (%s)
 	`, strings.Join(placeholders, ", "))
@@ -1152,7 +1152,7 @@ func (d *Database) GetChildChunks(parentID string) ([]*Memory, error) {
 		SELECT id, content, source, importance, tags, session_id, domain,
 		       embedding, created_at, updated_at, agent_type, agent_context,
 		       access_scope, slug, parent_memory_id, chunk_level, chunk_index,
-		       cc_session_id
+		       conversation_id
 		FROM memories
 		WHERE parent_memory_id = ?
 		ORDER BY chunk_index ASC
@@ -1189,7 +1189,7 @@ func (d *Database) GetRootMemories(filters *MemoryFilters) ([]*Memory, error) {
 		SELECT id, content, source, importance, tags, session_id, domain,
 		       embedding, created_at, updated_at, agent_type, agent_context,
 		       access_scope, slug, parent_memory_id, chunk_level, chunk_index,
-		       cc_session_id
+		       conversation_id
 		FROM memories
 		WHERE ` + strings.Join(whereClauses, " AND ") + `
 		ORDER BY created_at DESC
@@ -1236,7 +1236,7 @@ func scanMemories(rows *sql.Rows) ([]*Memory, error) {
 		m.AgentContext = agentContext.String
 		m.Slug = slug.String
 		m.ParentMemoryID = parentMemoryID.String
-		m.CCSessionID = ccSessionID.String
+		m.ConversationID = ccSessionID.String
 		m.Embedding = embedding
 		m.Tags = ParseTags(tagsJSON)
 

--- a/internal/database/operations_chat.go
+++ b/internal/database/operations_chat.go
@@ -10,11 +10,11 @@ import (
 )
 
 // =============================================================================
-// CC SESSION OPERATIONS
+// CONVERSATION OPERATIONS
 // =============================================================================
 
-// CreateCCSession creates a new Claude Code chat session
-func (d *Database) CreateCCSession(s *CCSession) error {
+// CreateCCSession creates a new conversation record
+func (d *Database) CreateCCSession(s *Conversation) error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
@@ -29,7 +29,7 @@ func (d *Database) CreateCCSession(s *CCSession) error {
 	s.UpdatedAt = now
 
 	_, err := d.db.Exec(`
-		INSERT INTO cc_sessions (
+		INSERT INTO conversations (
 			id, session_id, project_path, project_hash, model, title, first_prompt,
 			summary, created_at, updated_at, last_activity,
 			message_count, user_message_count, assistant_message_count, tool_call_count,
@@ -45,30 +45,30 @@ func (d *Database) CreateCCSession(s *CCSession) error {
 	)
 
 	if err != nil {
-		return fmt.Errorf("failed to create cc_session: %w", err)
+		return fmt.Errorf("failed to create conversation: %w", err)
 	}
 
 	return nil
 }
 
-// GetCCSession retrieves a chat session by internal ID
-func (d *Database) GetCCSession(id string) (*CCSession, error) {
+// GetCCSession retrieves a conversation by internal ID
+func (d *Database) GetCCSession(id string) (*Conversation, error) {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 
-	return d.getCCSessionByQuery("SELECT id, session_id, project_path, project_hash, model, title, first_prompt, summary, created_at, updated_at, last_activity, message_count, user_message_count, assistant_message_count, tool_call_count, source_id, file_path, last_sync_position, summary_memory_id FROM cc_sessions WHERE id = ?", id)
+	return d.getConversationByQuery("SELECT id, session_id, project_path, project_hash, model, title, first_prompt, summary, created_at, updated_at, last_activity, message_count, user_message_count, assistant_message_count, tool_call_count, source_id, file_path, last_sync_position, summary_memory_id FROM conversations WHERE id = ?", id)
 }
 
-// GetCCSessionBySessionID retrieves a chat session by project hash + Claude session ID (dedup lookup)
-func (d *Database) GetCCSessionBySessionID(projectHash, sessionID string) (*CCSession, error) {
+// GetCCSessionBySessionID retrieves a conversation by project hash + session ID (dedup lookup)
+func (d *Database) GetCCSessionBySessionID(projectHash, sessionID string) (*Conversation, error) {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 
-	return d.getCCSessionByQuery("SELECT id, session_id, project_path, project_hash, model, title, first_prompt, summary, created_at, updated_at, last_activity, message_count, user_message_count, assistant_message_count, tool_call_count, source_id, file_path, last_sync_position, summary_memory_id FROM cc_sessions WHERE project_hash = ? AND session_id = ?", projectHash, sessionID)
+	return d.getConversationByQuery("SELECT id, session_id, project_path, project_hash, model, title, first_prompt, summary, created_at, updated_at, last_activity, message_count, user_message_count, assistant_message_count, tool_call_count, source_id, file_path, last_sync_position, summary_memory_id FROM conversations WHERE project_hash = ? AND session_id = ?", projectHash, sessionID)
 }
 
-func (d *Database) getCCSessionByQuery(query string, args ...interface{}) (*CCSession, error) {
-	var s CCSession
+func (d *Database) getConversationByQuery(query string, args ...interface{}) (*Conversation, error) {
+	var s Conversation
 	var model, title, firstPrompt, summary, sourceID, filePath, lastSyncPos, summaryMemID sql.NullString
 	var lastActivity sql.NullTime
 
@@ -84,7 +84,7 @@ func (d *Database) getCCSessionByQuery(query string, args ...interface{}) (*CCSe
 		return nil, nil
 	}
 	if err != nil {
-		return nil, fmt.Errorf("failed to get cc_session: %w", err)
+		return nil, fmt.Errorf("failed to get conversation: %w", err)
 	}
 
 	s.Model = model.String
@@ -102,8 +102,8 @@ func (d *Database) getCCSessionByQuery(query string, args ...interface{}) (*CCSe
 	return &s, nil
 }
 
-// ListCCSessions retrieves chat sessions with optional filters
-func (d *Database) ListCCSessions(filters *CCSessionFilters) ([]*CCSession, error) {
+// ListCCSessions retrieves conversations with optional filters
+func (d *Database) ListCCSessions(filters *ConversationFilters) ([]*Conversation, error) {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 
@@ -124,7 +124,7 @@ func (d *Database) ListCCSessions(filters *CCSessionFilters) ([]*CCSession, erro
 		       summary, created_at, updated_at, last_activity,
 		       message_count, user_message_count, assistant_message_count, tool_call_count,
 		       source_id, file_path, last_sync_position, summary_memory_id
-		FROM cc_sessions
+		FROM conversations
 	`
 
 	if len(whereClauses) > 0 {
@@ -145,15 +145,15 @@ func (d *Database) ListCCSessions(filters *CCSessionFilters) ([]*CCSession, erro
 
 	rows, err := d.db.Query(query, args...)
 	if err != nil {
-		return nil, fmt.Errorf("failed to list cc_sessions: %w", err)
+		return nil, fmt.Errorf("failed to list conversations: %w", err)
 	}
 	defer rows.Close()
 
-	return scanCCSessions(rows)
+	return scanConversations(rows)
 }
 
-// UpdateCCSession updates an existing chat session
-func (d *Database) UpdateCCSession(id string, updates *CCSessionUpdate) error {
+// UpdateCCSession updates an existing conversation
+func (d *Database) UpdateCCSession(id string, updates *ConversationUpdate) error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
@@ -201,45 +201,45 @@ func (d *Database) UpdateCCSession(id string, updates *CCSessionUpdate) error {
 	args = append(args, time.Now())
 	args = append(args, id)
 
-	query := fmt.Sprintf("UPDATE cc_sessions SET %s WHERE id = ?", strings.Join(setClauses, ", "))
+	query := fmt.Sprintf("UPDATE conversations SET %s WHERE id = ?", strings.Join(setClauses, ", "))
 
 	result, err := d.db.Exec(query, args...)
 	if err != nil {
-		return fmt.Errorf("failed to update cc_session: %w", err)
+		return fmt.Errorf("failed to update conversation: %w", err)
 	}
 
 	rows, _ := result.RowsAffected()
 	if rows == 0 {
-		return fmt.Errorf("cc_session not found: %s", id)
+		return fmt.Errorf("conversation not found: %s", id)
 	}
 
 	return nil
 }
 
-// DeleteCCSession removes a chat session by ID (CASCADE deletes messages and tool calls)
+// DeleteCCSession removes a conversation by ID (CASCADE deletes messages and actions)
 func (d *Database) DeleteCCSession(id string) error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
-	result, err := d.db.Exec("DELETE FROM cc_sessions WHERE id = ?", id)
+	result, err := d.db.Exec("DELETE FROM conversations WHERE id = ?", id)
 	if err != nil {
-		return fmt.Errorf("failed to delete cc_session: %w", err)
+		return fmt.Errorf("failed to delete conversation: %w", err)
 	}
 
 	rows, _ := result.RowsAffected()
 	if rows == 0 {
-		return fmt.Errorf("cc_session not found: %s", id)
+		return fmt.Errorf("conversation not found: %s", id)
 	}
 
 	return nil
 }
 
 // =============================================================================
-// CC MESSAGE OPERATIONS
+// MESSAGE OPERATIONS
 // =============================================================================
 
-// CreateCCMessage creates a new message in a chat session
-func (d *Database) CreateCCMessage(m *CCMessage) error {
+// CreateCCMessage creates a new message in a conversation
+func (d *Database) CreateCCMessage(m *ConversationMessage) error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
@@ -248,7 +248,7 @@ func (d *Database) CreateCCMessage(m *CCMessage) error {
 	}
 
 	_, err := d.db.Exec(`
-		INSERT INTO cc_messages (
+		INSERT INTO messages (
 			id, session_id, role, content, timestamp, sequence_index, has_tool_use, token_count
 		) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
 	`,
@@ -257,14 +257,14 @@ func (d *Database) CreateCCMessage(m *CCMessage) error {
 	)
 
 	if err != nil {
-		return fmt.Errorf("failed to create cc_message: %w", err)
+		return fmt.Errorf("failed to create message: %w", err)
 	}
 
 	return nil
 }
 
-// GetCCMessages retrieves messages for a session ordered by sequence index
-func (d *Database) GetCCMessages(sessionID string, limit, offset int) ([]*CCMessage, error) {
+// GetCCMessages retrieves messages for a conversation ordered by sequence index
+func (d *Database) GetCCMessages(sessionID string, limit, offset int) ([]*ConversationMessage, error) {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 
@@ -274,21 +274,21 @@ func (d *Database) GetCCMessages(sessionID string, limit, offset int) ([]*CCMess
 
 	rows, err := d.db.Query(`
 		SELECT id, session_id, role, content, timestamp, sequence_index, has_tool_use, token_count
-		FROM cc_messages
+		FROM messages
 		WHERE session_id = ?
 		ORDER BY sequence_index ASC
 		LIMIT ? OFFSET ?
 	`, sessionID, limit, offset)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get cc_messages: %w", err)
+		return nil, fmt.Errorf("failed to get messages: %w", err)
 	}
 	defer rows.Close()
 
-	return scanCCMessages(rows)
+	return scanConversationMessages(rows)
 }
 
-// SearchCCMessages searches messages by content across sessions
-func (d *Database) SearchCCMessages(query string, projectPath string, limit int) ([]*CCMessage, error) {
+// SearchCCMessages searches messages by content across conversations
+func (d *Database) SearchCCMessages(query string, projectPath string, limit int) ([]*ConversationMessage, error) {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 
@@ -301,8 +301,8 @@ func (d *Database) SearchCCMessages(query string, projectPath string, limit int)
 
 	sqlQuery := `
 		SELECT m.id, m.session_id, m.role, m.content, m.timestamp, m.sequence_index, m.has_tool_use, m.token_count
-		FROM cc_messages m
-		JOIN cc_sessions s ON s.id = m.session_id
+		FROM messages m
+		JOIN conversations s ON s.id = m.session_id
 		WHERE m.content LIKE ?
 	`
 	args = append(args, searchPattern)
@@ -317,19 +317,19 @@ func (d *Database) SearchCCMessages(query string, projectPath string, limit int)
 
 	rows, err := d.db.Query(sqlQuery, args...)
 	if err != nil {
-		return nil, fmt.Errorf("failed to search cc_messages: %w", err)
+		return nil, fmt.Errorf("failed to search messages: %w", err)
 	}
 	defer rows.Close()
 
-	return scanCCMessages(rows)
+	return scanConversationMessages(rows)
 }
 
 // =============================================================================
-// CC TOOL CALL OPERATIONS
+// ACTION OPERATIONS
 // =============================================================================
 
-// CreateCCToolCall creates a new tool call record
-func (d *Database) CreateCCToolCall(tc *CCToolCall) error {
+// CreateCCToolCall creates a new action record
+func (d *Database) CreateCCToolCall(tc *ConversationAction) error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
@@ -338,7 +338,7 @@ func (d *Database) CreateCCToolCall(tc *CCToolCall) error {
 	}
 
 	_, err := d.db.Exec(`
-		INSERT INTO cc_tool_calls (
+		INSERT INTO actions (
 			id, session_id, message_id, tool_name, input_json, result_text,
 			success, filepath, operation, timestamp
 		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
@@ -350,41 +350,41 @@ func (d *Database) CreateCCToolCall(tc *CCToolCall) error {
 	)
 
 	if err != nil {
-		return fmt.Errorf("failed to create cc_tool_call: %w", err)
+		return fmt.Errorf("failed to create action: %w", err)
 	}
 
 	return nil
 }
 
-// GetCCToolCalls retrieves tool calls for a session
-func (d *Database) GetCCToolCalls(sessionID string) ([]*CCToolCall, error) {
+// GetCCToolCalls retrieves actions for a conversation
+func (d *Database) GetCCToolCalls(sessionID string) ([]*ConversationAction, error) {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 
 	rows, err := d.db.Query(`
 		SELECT id, session_id, message_id, tool_name, input_json, result_text,
 		       success, filepath, operation, timestamp
-		FROM cc_tool_calls
+		FROM actions
 		WHERE session_id = ?
 		ORDER BY timestamp ASC
 	`, sessionID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get cc_tool_calls: %w", err)
+		return nil, fmt.Errorf("failed to get actions: %w", err)
 	}
 	defer rows.Close()
 
-	return scanCCToolCalls(rows)
+	return scanConversationActions(rows)
 }
 
-// GetFileOperations retrieves file-touching tool calls for a session
-func (d *Database) GetFileOperations(sessionID string) ([]*CCToolCall, error) {
+// GetFileOperations retrieves file-touching actions for a conversation
+func (d *Database) GetFileOperations(sessionID string) ([]*ConversationAction, error) {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 
 	rows, err := d.db.Query(`
 		SELECT id, session_id, message_id, tool_name, input_json, result_text,
 		       success, filepath, operation, timestamp
-		FROM cc_tool_calls
+		FROM actions
 		WHERE session_id = ? AND filepath IS NOT NULL AND filepath != ''
 		ORDER BY timestamp ASC
 	`, sessionID)
@@ -393,15 +393,15 @@ func (d *Database) GetFileOperations(sessionID string) ([]*CCToolCall, error) {
 	}
 	defer rows.Close()
 
-	return scanCCToolCalls(rows)
+	return scanConversationActions(rows)
 }
 
 // =============================================================================
 // CROSS-LAYER OPERATIONS
 // =============================================================================
 
-// GetSessionMemories retrieves memories linked to a chat session
-func (d *Database) GetSessionMemories(ccSessionID string, limit, offset int) ([]*Memory, error) {
+// GetSessionMemories retrieves memories linked to a conversation
+func (d *Database) GetSessionMemories(conversationID string, limit, offset int) ([]*Memory, error) {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 
@@ -413,12 +413,12 @@ func (d *Database) GetSessionMemories(ccSessionID string, limit, offset int) ([]
 		SELECT id, content, source, importance, tags, session_id, domain,
 		       embedding, created_at, updated_at, agent_type, agent_context,
 		       access_scope, slug, parent_memory_id, chunk_level, chunk_index,
-		       cc_session_id
+		       conversation_id
 		FROM memories
-		WHERE cc_session_id = ?
+		WHERE conversation_id = ?
 		ORDER BY created_at DESC
 		LIMIT ? OFFSET ?
-	`, ccSessionID, limit, offset)
+	`, conversationID, limit, offset)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get session memories: %w", err)
 	}
@@ -427,16 +427,16 @@ func (d *Database) GetSessionMemories(ccSessionID string, limit, offset int) ([]
 	return scanMemories(rows)
 }
 
-// UpdateMemoryCCSession links a memory to a chat session
-func (d *Database) UpdateMemoryCCSession(memoryID, ccSessionID string) error {
+// UpdateMemoryCCSession links a memory to a conversation
+func (d *Database) UpdateMemoryCCSession(memoryID, conversationID string) error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
 	result, err := d.db.Exec(`
-		UPDATE memories SET cc_session_id = ?, updated_at = ? WHERE id = ?
-	`, nullString(ccSessionID), time.Now(), memoryID)
+		UPDATE memories SET conversation_id = ?, updated_at = ? WHERE id = ?
+	`, nullString(conversationID), time.Now(), memoryID)
 	if err != nil {
-		return fmt.Errorf("failed to update memory cc_session: %w", err)
+		return fmt.Errorf("failed to update memory conversation: %w", err)
 	}
 
 	rows, _ := result.RowsAffected()
@@ -447,21 +447,21 @@ func (d *Database) UpdateMemoryCCSession(memoryID, ccSessionID string) error {
 	return nil
 }
 
-// LinkSessionToSummaryMemory sets the summary_memory_id on a chat session
-func (d *Database) LinkSessionToSummaryMemory(ccSessionID, summaryMemoryID string) error {
+// LinkSessionToSummaryMemory sets the summary_memory_id on a conversation
+func (d *Database) LinkSessionToSummaryMemory(conversationID, summaryMemoryID string) error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
 	result, err := d.db.Exec(`
-		UPDATE cc_sessions SET summary_memory_id = ?, updated_at = ? WHERE id = ?
-	`, summaryMemoryID, time.Now(), ccSessionID)
+		UPDATE conversations SET summary_memory_id = ?, updated_at = ? WHERE id = ?
+	`, summaryMemoryID, time.Now(), conversationID)
 	if err != nil {
-		return fmt.Errorf("failed to link session to summary memory: %w", err)
+		return fmt.Errorf("failed to link conversation to summary memory: %w", err)
 	}
 
 	rows, _ := result.RowsAffected()
 	if rows == 0 {
-		return fmt.Errorf("cc_session not found: %s", ccSessionID)
+		return fmt.Errorf("conversation not found: %s", conversationID)
 	}
 
 	return nil
@@ -471,10 +471,10 @@ func (d *Database) LinkSessionToSummaryMemory(ccSessionID, summaryMemoryID strin
 // SCAN HELPERS
 // =============================================================================
 
-func scanCCSessions(rows *sql.Rows) ([]*CCSession, error) {
-	var sessions []*CCSession
+func scanConversations(rows *sql.Rows) ([]*Conversation, error) {
+	var sessions []*Conversation
 	for rows.Next() {
-		var s CCSession
+		var s Conversation
 		var model, title, firstPrompt, summary, sourceID, filePath, lastSyncPos, summaryMemID sql.NullString
 		var lastActivity sql.NullTime
 
@@ -486,7 +486,7 @@ func scanCCSessions(rows *sql.Rows) ([]*CCSession, error) {
 			&sourceID, &filePath, &lastSyncPos, &summaryMemID,
 		)
 		if err != nil {
-			return nil, fmt.Errorf("failed to scan cc_session: %w", err)
+			return nil, fmt.Errorf("failed to scan conversation: %w", err)
 		}
 
 		s.Model = model.String
@@ -506,10 +506,13 @@ func scanCCSessions(rows *sql.Rows) ([]*CCSession, error) {
 	return sessions, nil
 }
 
-func scanCCMessages(rows *sql.Rows) ([]*CCMessage, error) {
-	var messages []*CCMessage
+// scanCCSessions is an alias for backward compatibility
+var scanCCSessions = scanConversations
+
+func scanConversationMessages(rows *sql.Rows) ([]*ConversationMessage, error) {
+	var messages []*ConversationMessage
 	for rows.Next() {
-		var m CCMessage
+		var m ConversationMessage
 		var timestamp sql.NullTime
 
 		err := rows.Scan(
@@ -517,7 +520,7 @@ func scanCCMessages(rows *sql.Rows) ([]*CCMessage, error) {
 			&timestamp, &m.SequenceIndex, &m.HasToolUse, &m.TokenCount,
 		)
 		if err != nil {
-			return nil, fmt.Errorf("failed to scan cc_message: %w", err)
+			return nil, fmt.Errorf("failed to scan message: %w", err)
 		}
 
 		if timestamp.Valid {
@@ -529,10 +532,13 @@ func scanCCMessages(rows *sql.Rows) ([]*CCMessage, error) {
 	return messages, nil
 }
 
-func scanCCToolCalls(rows *sql.Rows) ([]*CCToolCall, error) {
-	var toolCalls []*CCToolCall
+// scanCCMessages is an alias for backward compatibility
+var scanCCMessages = scanConversationMessages
+
+func scanConversationActions(rows *sql.Rows) ([]*ConversationAction, error) {
+	var actions []*ConversationAction
 	for rows.Next() {
-		var tc CCToolCall
+		var tc ConversationAction
 		var messageID, inputJSON, resultText, filePath, operation sql.NullString
 		var timestamp sql.NullTime
 
@@ -542,7 +548,7 @@ func scanCCToolCalls(rows *sql.Rows) ([]*CCToolCall, error) {
 			&timestamp,
 		)
 		if err != nil {
-			return nil, fmt.Errorf("failed to scan cc_tool_call: %w", err)
+			return nil, fmt.Errorf("failed to scan action: %w", err)
 		}
 
 		tc.MessageID = messageID.String
@@ -554,7 +560,10 @@ func scanCCToolCalls(rows *sql.Rows) ([]*CCToolCall, error) {
 			tc.Timestamp = &timestamp.Time
 		}
 
-		toolCalls = append(toolCalls, &tc)
+		actions = append(actions, &tc)
 	}
-	return toolCalls, nil
+	return actions, nil
 }
+
+// scanCCToolCalls is an alias for backward compatibility
+var scanCCToolCalls = scanConversationActions

--- a/internal/database/operations_source.go
+++ b/internal/database/operations_source.go
@@ -532,7 +532,7 @@ func (d *Database) GetMemoriesBySource(sourceID string, limit, offset int) ([]*M
 		SELECT id, content, source, importance, tags, session_id, domain,
 		       embedding, created_at, updated_at, agent_type, agent_context,
 		       access_scope, slug, parent_memory_id, chunk_level, chunk_index,
-		       source_id, external_id, cc_session_id
+		       source_id, external_id, conversation_id
 		FROM memories
 		WHERE source_id = ?
 		ORDER BY created_at DESC
@@ -632,7 +632,7 @@ func scanMemoriesWithSource(rows *sql.Rows) ([]*Memory, error) {
 		m.ParentMemoryID = parentMemoryID.String
 		m.SourceID = sourceID.String
 		m.ExternalID = externalID.String
-		m.CCSessionID = ccSessionID.String
+		m.ConversationID = ccSessionID.String
 		m.Embedding = embedding
 		m.Tags = ParseTags(tagsJSON)
 

--- a/internal/database/schema.go
+++ b/internal/database/schema.go
@@ -9,7 +9,7 @@ package database
 // - Metadata: performance_metrics, migration_log, schema_version, sqlite_sequence
 
 // SchemaVersion is the current schema version
-const SchemaVersion = 4
+const SchemaVersion = 5
 
 // CoreSchema contains the main table definitions
 // VERIFIED: Exact schema from ~/.local-memory/unified-memories.db
@@ -46,8 +46,8 @@ CREATE TABLE IF NOT EXISTS memories (
 	parent_memory_id TEXT REFERENCES memories(id) ON DELETE CASCADE,
 	chunk_level INTEGER DEFAULT 0,  -- 0=full, 1=paragraph, 2=atomic
 	chunk_index INTEGER DEFAULT 0,  -- position within parent
-	-- Chat history linkage
-	cc_session_id TEXT
+	-- Conversation linkage (any source)
+	conversation_id TEXT
 );
 
 -- VERIFIED: 9 indexes on memories table
@@ -60,7 +60,7 @@ CREATE INDEX IF NOT EXISTS idx_memories_slug ON memories(slug);
 CREATE UNIQUE INDEX IF NOT EXISTS idx_memories_slug_unique ON memories(slug) WHERE slug IS NOT NULL;
 CREATE INDEX IF NOT EXISTS idx_memories_parent ON memories(parent_memory_id);
 CREATE INDEX IF NOT EXISTS idx_memories_chunk_level ON memories(chunk_level);
-CREATE INDEX IF NOT EXISTS idx_memories_cc_session ON memories(cc_session_id);
+CREATE INDEX IF NOT EXISTS idx_memories_conversation ON memories(conversation_id);
 
 -- =============================================================================
 -- MEMORY RELATIONSHIPS TABLE
@@ -288,14 +288,14 @@ CREATE INDEX IF NOT EXISTS idx_sync_history_status ON data_source_sync_history(s
 CREATE INDEX IF NOT EXISTS idx_sync_history_started ON data_source_sync_history(started_at);
 `
 
-// ChatHistorySchema contains the Claude Code chat history tables
-// Added in schema version 4 for conversation tracking
-const ChatHistorySchema = `
+// ConversationSchema contains the conversation tracking tables (generalized from cc_* tables)
+// Originally added in schema version 4 for Claude Code, generalized in v5 for all sources
+const ConversationSchema = `
 -- =============================================================================
--- CLAUDE CODE CHAT SESSIONS TABLE
--- Parsed from ~/.claude/projects/*/JSONL files
+-- CONVERSATIONS TABLE
+-- Ingested conversations from any source (Claude Code, Slack, Discord, etc.)
 -- =============================================================================
-CREATE TABLE IF NOT EXISTS cc_sessions (
+CREATE TABLE IF NOT EXISTS conversations (
 	id TEXT PRIMARY KEY,
 	session_id TEXT NOT NULL,
 	project_path TEXT NOT NULL,
@@ -318,19 +318,19 @@ CREATE TABLE IF NOT EXISTS cc_sessions (
 	FOREIGN KEY (source_id) REFERENCES data_sources(id) ON DELETE SET NULL,
 	FOREIGN KEY (summary_memory_id) REFERENCES memories(id) ON DELETE SET NULL
 );
-CREATE INDEX IF NOT EXISTS idx_cc_sessions_session_id ON cc_sessions(session_id);
-CREATE INDEX IF NOT EXISTS idx_cc_sessions_project ON cc_sessions(project_path);
-CREATE INDEX IF NOT EXISTS idx_cc_sessions_hash ON cc_sessions(project_hash);
-CREATE INDEX IF NOT EXISTS idx_cc_sessions_created ON cc_sessions(created_at);
-CREATE UNIQUE INDEX IF NOT EXISTS idx_cc_sessions_dedup ON cc_sessions(project_hash, session_id);
+CREATE INDEX IF NOT EXISTS idx_conversations_session_id ON conversations(session_id);
+CREATE INDEX IF NOT EXISTS idx_conversations_project ON conversations(project_path);
+CREATE INDEX IF NOT EXISTS idx_conversations_hash ON conversations(project_hash);
+CREATE INDEX IF NOT EXISTS idx_conversations_created ON conversations(created_at);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_conversations_dedup ON conversations(project_hash, session_id);
 
 -- =============================================================================
--- CLAUDE CODE MESSAGES TABLE
--- Individual messages (append-only, mirrors JSONL structure)
+-- MESSAGES TABLE
+-- Individual messages from any conversation source
 -- =============================================================================
-CREATE TABLE IF NOT EXISTS cc_messages (
+CREATE TABLE IF NOT EXISTS messages (
 	id TEXT PRIMARY KEY,
-	session_id TEXT NOT NULL REFERENCES cc_sessions(id) ON DELETE CASCADE,
+	session_id TEXT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
 	role TEXT NOT NULL,
 	content TEXT,
 	timestamp DATETIME,
@@ -338,18 +338,18 @@ CREATE TABLE IF NOT EXISTS cc_messages (
 	has_tool_use BOOLEAN DEFAULT 0,
 	token_count INTEGER DEFAULT 0
 );
-CREATE INDEX IF NOT EXISTS idx_cc_messages_session ON cc_messages(session_id);
-CREATE INDEX IF NOT EXISTS idx_cc_messages_role ON cc_messages(role);
-CREATE INDEX IF NOT EXISTS idx_cc_messages_seq ON cc_messages(session_id, sequence_index);
+CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(session_id);
+CREATE INDEX IF NOT EXISTS idx_messages_role ON messages(role);
+CREATE INDEX IF NOT EXISTS idx_messages_seq ON messages(session_id, sequence_index);
 
 -- =============================================================================
--- CLAUDE CODE TOOL CALLS TABLE
--- Tool calls extracted from assistant messages
+-- ACTIONS TABLE
+-- Tool calls, reactions, and other actions extracted from messages
 -- =============================================================================
-CREATE TABLE IF NOT EXISTS cc_tool_calls (
+CREATE TABLE IF NOT EXISTS actions (
 	id TEXT PRIMARY KEY,
-	session_id TEXT NOT NULL REFERENCES cc_sessions(id) ON DELETE CASCADE,
-	message_id TEXT REFERENCES cc_messages(id) ON DELETE CASCADE,
+	session_id TEXT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+	message_id TEXT REFERENCES messages(id) ON DELETE CASCADE,
 	tool_name TEXT NOT NULL,
 	input_json TEXT,
 	result_text TEXT,
@@ -358,9 +358,9 @@ CREATE TABLE IF NOT EXISTS cc_tool_calls (
 	operation TEXT,
 	timestamp DATETIME
 );
-CREATE INDEX IF NOT EXISTS idx_cc_tool_calls_session ON cc_tool_calls(session_id);
-CREATE INDEX IF NOT EXISTS idx_cc_tool_calls_name ON cc_tool_calls(tool_name);
-CREATE INDEX IF NOT EXISTS idx_cc_tool_calls_filepath ON cc_tool_calls(filepath);
+CREATE INDEX IF NOT EXISTS idx_actions_session ON actions(session_id);
+CREATE INDEX IF NOT EXISTS idx_actions_name ON actions(tool_name);
+CREATE INDEX IF NOT EXISTS idx_actions_filepath ON actions(filepath);
 `
 
 // DataSourceTypes contains the supported source types

--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -323,7 +323,7 @@ func (s *Server) handleStoreMemory(ctx context.Context, argsJSON []byte) (interf
 		Tags:        params.Tags,
 		Domain:      params.Domain,
 		Source:       params.Source,
-		CCSessionID: params.CCSessionID,
+		ConversationID: params.ConversationID,
 	})
 	if err != nil {
 		s.log.Error("failed to store memory", "error", err)
@@ -1314,7 +1314,7 @@ func (s *Server) handleTraceSource(ctx context.Context, argsJSON []byte) (interf
 		return nil, fmt.Errorf("memory not found: %w", err)
 	}
 
-	if mem.CCSessionID == "" {
+	if mem.ConversationID == "" {
 		return map[string]interface{}{
 			"memory_id": mem.ID,
 			"has_source": false,
@@ -1322,19 +1322,19 @@ func (s *Server) handleTraceSource(ctx context.Context, argsJSON []byte) (interf
 		}, nil
 	}
 
-	// Get the linked session
-	sess, err := s.db.GetCCSession(mem.CCSessionID)
+	// Get the linked conversation
+	sess, err := s.db.GetCCSession(mem.ConversationID)
 	if err != nil {
 		return map[string]interface{}{
-			"memory_id":     mem.ID,
-			"cc_session_id": mem.CCSessionID,
-			"has_source":    false,
-			"message":       "Linked session not found",
+			"memory_id":       mem.ID,
+			"conversation_id": mem.ConversationID,
+			"has_source":      false,
+			"message":         "Linked conversation not found",
 		}, nil
 	}
 
 	// Get surrounding messages
-	messages, err := s.db.GetCCMessages(mem.CCSessionID, 20, 0)
+	messages, err := s.db.GetCCMessages(mem.ConversationID, 20, 0)
 	if err != nil {
 		messages = nil
 	}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -546,9 +546,9 @@ func (s *Server) getToolDefinitions() []Tool {
 						Type:        "string",
 						Description: "Source of the memory",
 					},
-					"cc_session_id": {
+					"conversation_id": {
 						Type:        "string",
-						Description: "Optional: link to a Claude Code chat session",
+						Description: "Optional: link to a conversation from any source",
 					},
 				},
 				Required: []string{"content"},

--- a/internal/mcp/types.go
+++ b/internal/mcp/types.go
@@ -154,7 +154,7 @@ type StoreMemoryParams struct {
 	Tags        []string `json:"tags,omitempty"`
 	Domain      string   `json:"domain,omitempty"`
 	Source      string   `json:"source,omitempty"`
-	CCSessionID string   `json:"cc_session_id,omitempty"`
+	ConversationID string `json:"conversation_id,omitempty"`
 }
 
 // SearchParams for search tool

--- a/internal/memory/service.go
+++ b/internal/memory/service.go
@@ -58,7 +58,7 @@ type StoreOptions struct {
 	AgentContext string // Optional override
 	AccessScope  string // "session", "shared", "global"
 	Slug         string
-	CCSessionID  string // Optional: link to a Claude Code chat session
+	ConversationID string // Optional: link to a conversation
 }
 
 // StoreResult contains the result of storing a memory
@@ -151,7 +151,7 @@ func (s *Service) Store(opts *StoreOptions) (*StoreResult, error) {
 		Slug:         opts.Slug,
 		ChunkLevel:   0, // Root level
 		ChunkIndex:   0,
-		CCSessionID:  opts.CCSessionID,
+		ConversationID: opts.ConversationID,
 	}
 
 	// Store in database
@@ -182,7 +182,7 @@ func (s *Service) storeWithChunks(opts *StoreOptions, content string, importance
 		Slug:         opts.Slug,
 		ChunkLevel:   0, // Root level
 		ChunkIndex:   0,
-		CCSessionID:  opts.CCSessionID,
+		ConversationID: opts.ConversationID,
 	}
 
 	if err := s.db.CreateMemory(parentMemory); err != nil {

--- a/internal/pipeline/transformer.go
+++ b/internal/pipeline/transformer.go
@@ -298,7 +298,7 @@ func (t *Transformer) createSummaryMemory(_ context.Context, session *database.C
 		UpdatedAt:   time.Now(),
 		AgentType:   sourceType,
 		AccessScope: "session",
-		CCSessionID: session.ID,
+		ConversationID: session.ID,
 	}
 
 	if err := t.db.CreateMemory(mem); err != nil {


### PR DESCRIPTION
## Summary
- Renames `cc_sessions` → `conversations`, `cc_messages` → `messages`, `cc_tool_calls` → `actions`
- Renames `memories.cc_session_id` → `memories.conversation_id`
- Adds v4→v5 SQLite migration (ALTER TABLE RENAME + RENAME COLUMN)
- Updates all Go types (`Conversation`, `ConversationMessage`, `ConversationAction`) with backward-compatible type aliases
- Updates all SQL queries, MCP tool definitions, REST API handlers, and desktop TypeScript

## Test plan
- [x] Go binary compiles cleanly with `-ldflags "-s -w"`
- [x] Migration ran successfully on existing 20MB database (v4→v5)
- [x] Schema version confirmed as 5 via `schema_version` table
- [x] Tables confirmed renamed: `conversations`, `messages`, `actions` exist; `cc_*` tables gone
- [x] `memories.conversation_id` column confirmed via PRAGMA table_info
- [x] REST API health check passes
- [x] `/api/v1/chats` returns conversations with all data intact
- [x] `/api/v1/memories/:id` returns `conversation_id` field correctly
- [x] `/api/v1/memories/:id/trace` traces back to linked conversations
- [x] Desktop Knowledge Graph loads with 140 memories + 82 chats, 82 traced
- [x] Database backup taken before migration (`memories.db.v4-backup`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)