### PR TITLE
fix: memory.store() missing from Electron preload

### DIFF
--- a/desktop/src/main/preload.ts
+++ b/desktop/src/main/preload.ts
@@ -40,6 +40,8 @@ const api = {
       invoke('memory:get', id),
     create: (data: MemoryCreateInput): Promise<Memory> =>
       invoke('memory:create', data),
+    store: (data: MemoryCreateInput): Promise<Memory> =>
+      invoke('memory:create', data),
     update: (id: string, data: MemoryUpdateInput): Promise<Memory> =>
       invoke('memory:update', id, data),
     delete: (id: string): Promise<boolean> =>


### PR DESCRIPTION
## Summary
- CreateMemoryModal calls `memory.store()` but the Electron preload only exposed `memory.create()`
- The browser fallback (api-bridge.ts) had both aliases but the Electron IPC path was missing `store`, causing the "Create Memory" modal to silently fail in the desktop app
- Adds `store` as an alias for `create` in the preload's memory namespace

## Verified
- REST API memory creation: working
- MCP tool `store_memory`: working
- Database archive/export/import: all verified working at REST level
- Go binary rebuilt, backend restarted
- Frontend + main process TypeScript: clean build

## Test plan
- [ ] Open desktop app, press Ctrl+N, create a memory — should succeed
- [ ] Verify memory appears in Memory Browser
- [ ] Archive a database from Settings — should show backup path toast
- [ ] Export a database from Settings — should show native save dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)