### PR TITLE
fix: attach file dialogs to parent BrowserWindow on Windows

### DIFF
--- a/desktop/src/main/ipc/memory.ipc.ts
+++ b/desktop/src/main/ipc/memory.ipc.ts
@@ -4,7 +4,7 @@
  */
 
 import type { IpcMain } from 'electron';
-import { dialog } from 'electron';
+import { dialog, BrowserWindow } from 'electron';
 import { MycelicMemoryClient } from '../services/mycelicmemory-client';
 import type { MemoryCreateInput, MemoryUpdateInput, SearchOptions } from '../../shared/types';
 
@@ -187,16 +187,20 @@ export function registerMemoryHandlers(ipcMain: IpcMain, apiBaseUrl: string): vo
     }
   });
 
-  ipcMain.handle('databases:export', async (_event, name: string) => {
+  ipcMain.handle('databases:export', async (event, name: string) => {
     try {
-      const result = await dialog.showSaveDialog({
+      const win = BrowserWindow.fromWebContents(event.sender) || BrowserWindow.getFocusedWindow();
+      const dialogOpts: Electron.SaveDialogOptions = {
         title: `Export database "${name}"`,
         defaultPath: `${name}.db`,
         filters: [
           { name: 'SQLite Database', extensions: ['db'] },
           { name: 'All Files', extensions: ['*'] },
         ],
-      });
+      };
+      const result = win
+        ? await dialog.showSaveDialog(win, dialogOpts)
+        : await dialog.showSaveDialog(dialogOpts);
       if (result.canceled || !result.filePath) return null;
 
       await client.post<any>(`/databases/${encodeURIComponent(name)}/export`, {
@@ -209,16 +213,20 @@ export function registerMemoryHandlers(ipcMain: IpcMain, apiBaseUrl: string): vo
     }
   });
 
-  ipcMain.handle('databases:import', async () => {
+  ipcMain.handle('databases:import', async (event) => {
     try {
-      const result = await dialog.showOpenDialog({
+      const win = BrowserWindow.fromWebContents(event.sender) || BrowserWindow.getFocusedWindow();
+      const dialogOpts: Electron.OpenDialogOptions = {
         title: 'Import database',
         filters: [
           { name: 'SQLite Database', extensions: ['db'] },
           { name: 'All Files', extensions: ['*'] },
         ],
         properties: ['openFile'],
-      });
+      };
+      const result = win
+        ? await dialog.showOpenDialog(win, dialogOpts)
+        : await dialog.showOpenDialog(dialogOpts);
       if (result.canceled || result.filePaths.length === 0) return null;
 
       // Return the selected path — the renderer will prompt for a name


### PR DESCRIPTION
## Summary
- `dialog.showSaveDialog()` and `dialog.showOpenDialog()` were called without a parent `BrowserWindow` reference
- On Windows, this causes the native file dialog to open behind the app window or fail silently
- Now uses `BrowserWindow.fromWebContents(event.sender)` to attach dialogs to the correct window

## Root cause
Electron's `dialog.showSaveDialog(options)` (no window arg) creates a detached dialog on Windows that can appear behind the main window, making it look like nothing happened.

## Test plan
- [ ] Go to Settings > Database Management
- [ ] Click Export on any database — native Save dialog should appear in front
- [ ] Click Import Database — native Open dialog should appear in front
- [ ] Complete export flow — verify `.db` file created at chosen location
- [ ] Complete import flow — verify new database appears in list

🤖 Generated with [Claude Code](https://claude.com/claude-code)