### PR TITLE
feat: Knowledge Graph context menu, display settings & saveable views

### DIFF
--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -5,7 +5,21 @@
 
 import { app, BrowserWindow, ipcMain, shell } from 'electron';
 import * as path from 'path';
+import log from 'electron-log/main';
 import Store from 'electron-store';
+
+// Initialize electron-log
+log.initialize();
+log.transports.file.level = 'debug';
+log.transports.console.level = 'debug';
+
+// Global error handlers
+process.on('uncaughtException', (err) => {
+  log.error('Uncaught exception in main process', err);
+});
+process.on('unhandledRejection', (reason) => {
+  log.error('Unhandled rejection in main process', reason);
+});
 import { registerMemoryHandlers } from './ipc/memory.ipc';
 import { registerClaudeHandlers } from './ipc/claude.ipc';
 import { registerConfigHandlers } from './ipc/config.ipc';
@@ -13,11 +27,16 @@ import { registerClaudeChatStreamHandlers } from './ipc/claude-stream.ipc';
 import { MycelicMemoryClient } from './services/mycelicmemory-client';
 import { ServiceManager } from './services/service-manager';
 import { registerServicesHandlers } from './ipc/services.ipc';
-import { AppSettings } from '../shared/types';
+import { registerGraphViewsHandlers } from './ipc/graph-views.ipc';
+import { AppSettings, GraphViewStore } from '../shared/types';
 
 // Initialize electron-store for settings persistence
-const store = new Store<{ settings: AppSettings }>({
+const store = new Store<{ settings: AppSettings; graphViews: GraphViewStore }>({
   defaults: {
+    graphViews: {
+      views: [],
+      activeViewId: undefined,
+    },
     settings: {
       api_url: 'http://127.0.0.1',
       api_port: 3099,
@@ -112,6 +131,7 @@ function initializeServicesAndHandlers(): void {
   registerClaudeHandlers(ipcMain, client);
   registerConfigHandlers(ipcMain, store);
   registerServicesHandlers(ipcMain, serviceManager);
+  registerGraphViewsHandlers(ipcMain, store);
 
   if (mainWindow) {
     registerClaudeChatStreamHandlers(ipcMain, mainWindow, path.dirname(path.dirname(claudeDbPath)));
@@ -125,12 +145,12 @@ function initializeServicesAndHandlers(): void {
   // Now start services in the background (don't block the renderer)
   serviceManager.ensureAllServices()
     .then(() => {
-      console.log('[Main] All services initialized');
+      log.info('[Main] All services initialized');
       if (mainWindow) {
         serviceManager!.startStatusPolling(mainWindow);
       }
     })
-    .catch(err => console.error('[Main] Service initialization error:', err));
+    .catch(err => log.error('[Main] Service initialization error:', err));
 
 }
 

--- a/desktop/src/main/ipc/config.ipc.ts
+++ b/desktop/src/main/ipc/config.ipc.ts
@@ -10,7 +10,7 @@ import { app } from 'electron';
 
 export function registerConfigHandlers(
   ipcMain: IpcMain,
-  store: Store<{ settings: AppSettings }>
+  store: Store<any>
 ): void {
   // Get all settings
   ipcMain.handle('settings:get', () => {

--- a/desktop/src/main/ipc/graph-views.ipc.ts
+++ b/desktop/src/main/ipc/graph-views.ipc.ts
@@ -1,0 +1,58 @@
+/**
+ * Graph Views IPC Handlers
+ * Manages saved graph view configurations (filters, physics, style, hidden/pinned nodes)
+ */
+
+import type { IpcMain } from 'electron';
+import type Store from 'electron-store';
+import type { AppSettings, GraphView, GraphViewStore } from '../../shared/types';
+
+export function registerGraphViewsHandlers(
+  ipcMain: IpcMain,
+  store: Store<{ settings: AppSettings; graphViews: GraphViewStore }>
+): void {
+  ipcMain.handle('graph-views:list', () => {
+    return store.get('graphViews.views', []);
+  });
+
+  ipcMain.handle('graph-views:get', (_event, params: { id: string }) => {
+    const views = store.get('graphViews.views', []) as GraphView[];
+    return views.find((v) => v.id === params.id) ?? null;
+  });
+
+  ipcMain.handle('graph-views:save', (_event, view: GraphView) => {
+    const views = store.get('graphViews.views', []) as GraphView[];
+    const idx = views.findIndex((v) => v.id === view.id);
+    view.updated_at = new Date().toISOString();
+    if (idx >= 0) {
+      views[idx] = view;
+    } else {
+      views.push(view);
+    }
+    store.set('graphViews.views', views);
+    return view;
+  });
+
+  ipcMain.handle('graph-views:delete', (_event, params: { id: string }) => {
+    const views = store.get('graphViews.views', []) as GraphView[];
+    const filtered = views.filter((v) => v.id !== params.id);
+    store.set('graphViews.views', filtered);
+    const activeId = store.get('graphViews.activeViewId') as string | undefined;
+    if (activeId === params.id) {
+      store.set('graphViews.activeViewId', undefined);
+    }
+    return filtered.length < views.length;
+  });
+
+  ipcMain.handle('graph-views:set-active', (_event, params: { id: string | null }) => {
+    store.set('graphViews.activeViewId', params.id ?? undefined);
+    return true;
+  });
+
+  ipcMain.handle('graph-views:get-active', () => {
+    const activeId = store.get('graphViews.activeViewId') as string | undefined;
+    if (!activeId) return null;
+    const views = store.get('graphViews.views', []) as GraphView[];
+    return views.find((v) => v.id === activeId) ?? null;
+  });
+}

--- a/desktop/src/main/preload.ts
+++ b/desktop/src/main/preload.ts
@@ -23,6 +23,7 @@ import type {
   DatabaseInfo,
   ClaudeChatStreamStatus,
   ServiceStatus,
+  GraphView,
 } from '../shared/types';
 
 // Type-safe IPC invoke wrapper
@@ -165,6 +166,16 @@ const api = {
       ipcRenderer.on('services:status-update', handler);
       return () => ipcRenderer.removeListener('services:status-update', handler);
     },
+  },
+
+  // Graph views (saved configurations)
+  graphViews: {
+    list: (): Promise<GraphView[]> => invoke('graph-views:list'),
+    get: (id: string): Promise<GraphView | null> => invoke('graph-views:get', { id }),
+    save: (view: GraphView): Promise<GraphView> => invoke('graph-views:save', view),
+    delete: (id: string): Promise<boolean> => invoke('graph-views:delete', { id }),
+    setActive: (id: string | null): Promise<boolean> => invoke('graph-views:set-active', { id }),
+    getActive: (): Promise<GraphView | null> => invoke('graph-views:get-active'),
   },
 
   // Shell operations

--- a/desktop/src/renderer/api-bridge.ts
+++ b/desktop/src/renderer/api-bridge.ts
@@ -48,7 +48,25 @@ const browserApi = {
     store: async (data: any) => fetchApi<any>('/memories', { method: 'POST', body: JSON.stringify(data) }),
     update: async (id: string, data: any) => fetchApi<any>(`/memories/${id}`, { method: 'PUT', body: JSON.stringify(data) }),
     delete: async (id: string) => fetchApi<void>(`/memories/${id}`, { method: 'DELETE' }),
-    search: async (options: any) => fetchApi<any[]>('/memories/search', { method: 'POST', body: JSON.stringify(options) }),
+    search: async (options: any) => {
+      const raw = await fetchApi<any>('/memories/search', { method: 'POST', body: JSON.stringify(options) });
+      if (Array.isArray(raw?.data)) {
+        return raw.data.map((item: any) => ({
+          memory: {
+            id: item.id,
+            content: item.content,
+            domain: item.domain,
+            importance: item.importance,
+            tags: item.tags ?? [],
+            created_at: item.created_at,
+            updated_at: item.updated_at ?? item.created_at,
+          },
+          score: item.relevance_score,
+          similarity: item.relevance_score,
+        }));
+      }
+      return Array.isArray(raw) ? raw : [];
+    },
   },
   stats: {
     dashboard: async () => {
@@ -241,6 +259,54 @@ const browserApi = {
   },
   seed: {
     populate: async () => fetchApi<any>('/seed', { method: 'POST' }),
+  },
+  graphViews: {
+    list: async () => {
+      try {
+        const raw = localStorage.getItem('mycelicmemory-graph-views');
+        const store = raw ? JSON.parse(raw) : { views: [] };
+        return store.views || [];
+      } catch { return []; }
+    },
+    get: async (id: string) => {
+      const views = await browserApi.graphViews.list();
+      return views.find((v: any) => v.id === id) ?? null;
+    },
+    save: async (view: any) => {
+      const views = await browserApi.graphViews.list();
+      const idx = views.findIndex((v: any) => v.id === view.id);
+      view.updated_at = new Date().toISOString();
+      if (idx >= 0) views[idx] = view; else views.push(view);
+      const raw = localStorage.getItem('mycelicmemory-graph-views');
+      const store = raw ? JSON.parse(raw) : {};
+      store.views = views;
+      localStorage.setItem('mycelicmemory-graph-views', JSON.stringify(store));
+      return view;
+    },
+    delete: async (id: string) => {
+      const views = await browserApi.graphViews.list();
+      const filtered = views.filter((v: any) => v.id !== id);
+      const raw = localStorage.getItem('mycelicmemory-graph-views');
+      const store = raw ? JSON.parse(raw) : {};
+      store.views = filtered;
+      if (store.activeViewId === id) store.activeViewId = undefined;
+      localStorage.setItem('mycelicmemory-graph-views', JSON.stringify(store));
+      return filtered.length < views.length;
+    },
+    setActive: async (id: string | null) => {
+      const raw = localStorage.getItem('mycelicmemory-graph-views');
+      const store = raw ? JSON.parse(raw) : { views: [] };
+      store.activeViewId = id ?? undefined;
+      localStorage.setItem('mycelicmemory-graph-views', JSON.stringify(store));
+      return true;
+    },
+    getActive: async () => {
+      const raw = localStorage.getItem('mycelicmemory-graph-views');
+      const store = raw ? JSON.parse(raw) : {};
+      if (!store.activeViewId) return null;
+      const views = store.views || [];
+      return views.find((v: any) => v.id === store.activeViewId) ?? null;
+    },
   },
   services: {
     status: async () => {

--- a/desktop/src/renderer/components/graph/GraphContextMenu.tsx
+++ b/desktop/src/renderer/components/graph/GraphContextMenu.tsx
@@ -1,0 +1,96 @@
+import { useEffect, useRef } from 'react';
+import { Focus, EyeOff, Pin, PinOff, Copy, Hash, Eye, RotateCcw, Maximize2, Link } from 'lucide-react';
+
+export type ContextMenuAction =
+  | 'focus-neighborhood'
+  | 'show-only-connected'
+  | 'hide-node'
+  | 'pin-to-view'
+  | 'unpin-from-view'
+  | 'copy-content'
+  | 'copy-id'
+  | 'show-all-hidden'
+  | 'reset-view'
+  | 'fit-all';
+
+interface GraphContextMenuProps {
+  x: number;
+  y: number;
+  nodeId: string | null;
+  nodeType: 'memory' | 'session' | null;
+  isPinned: boolean;
+  hiddenCount: number;
+  onAction: (action: ContextMenuAction) => void;
+  onClose: () => void;
+}
+
+export default function GraphContextMenu({
+  x, y, nodeId, nodeType, isPinned, hiddenCount, onAction, onClose,
+}: GraphContextMenuProps) {
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        onClose();
+      }
+    }
+    function handleEscape(e: KeyboardEvent) {
+      if (e.key === 'Escape') onClose();
+    }
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('keydown', handleEscape);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [onClose]);
+
+  // Clamp position so menu doesn't go off-screen
+  const clampedX = Math.min(x, window.innerWidth - 220);
+  const clampedY = Math.min(y, window.innerHeight - 300);
+
+  const isNode = nodeId !== null;
+  const isMemory = nodeType === 'memory';
+
+  function item(label: string, action: ContextMenuAction, icon: React.ReactNode) {
+    return (
+      <button
+        onClick={() => { onAction(action); onClose(); }}
+        className="w-full flex items-center gap-2 px-3 py-1.5 text-sm text-slate-200 hover:bg-slate-600 rounded transition-colors text-left"
+      >
+        {icon}
+        {label}
+      </button>
+    );
+  }
+
+  return (
+    <div
+      ref={menuRef}
+      style={{ left: clampedX, top: clampedY }}
+      className="fixed z-50 w-52 bg-slate-700 border border-slate-600 rounded-lg shadow-xl py-1"
+    >
+      {isNode ? (
+        <>
+          {item('Focus Neighborhood', 'focus-neighborhood', <Focus className="w-3.5 h-3.5" />)}
+          {item('Show Only Connected', 'show-only-connected', <Link className="w-3.5 h-3.5" />)}
+          {item('Hide Node', 'hide-node', <EyeOff className="w-3.5 h-3.5" />)}
+          {isMemory && (
+            isPinned
+              ? item('Unpin from View', 'unpin-from-view', <PinOff className="w-3.5 h-3.5" />)
+              : item('Pin to View', 'pin-to-view', <Pin className="w-3.5 h-3.5" />)
+          )}
+          {isMemory && item('Copy Content', 'copy-content', <Copy className="w-3.5 h-3.5" />)}
+          {item('Copy ID', 'copy-id', <Hash className="w-3.5 h-3.5" />)}
+        </>
+      ) : (
+        <>
+          {hiddenCount > 0 && item(`Show All Hidden (${hiddenCount})`, 'show-all-hidden', <Eye className="w-3.5 h-3.5" />)}
+          {item('Reset View', 'reset-view', <RotateCcw className="w-3.5 h-3.5" />)}
+          {item('Fit All', 'fit-all', <Maximize2 className="w-3.5 h-3.5" />)}
+        </>
+      )}
+    </div>
+  );
+}

--- a/desktop/src/renderer/components/graph/GraphDisplaySettings.tsx
+++ b/desktop/src/renderer/components/graph/GraphDisplaySettings.tsx
@@ -1,0 +1,136 @@
+import { ChevronDown, ChevronUp, RotateCcw, X } from 'lucide-react';
+import { useState } from 'react';
+import type { GraphPhysicsSettings, GraphStyleSettings } from '../../../shared/types';
+
+interface GraphDisplaySettingsProps {
+  physics: GraphPhysicsSettings;
+  style: GraphStyleSettings;
+  onPhysicsChange: (physics: GraphPhysicsSettings) => void;
+  onStyleChange: (style: GraphStyleSettings) => void;
+  onReset: () => void;
+  onClose: () => void;
+}
+
+const SMOOTH_TYPES = ['dynamic', 'continuous', 'discrete', 'curvedCW', 'curvedCCW'];
+
+export default function GraphDisplaySettings({
+  physics, style, onPhysicsChange, onStyleChange, onReset, onClose,
+}: GraphDisplaySettingsProps) {
+  const [physicsOpen, setPhysicsOpen] = useState(true);
+  const [styleOpen, setStyleOpen] = useState(true);
+
+  function slider(
+    label: string,
+    value: number,
+    min: number,
+    max: number,
+    step: number,
+    onChange: (v: number) => void
+  ) {
+    return (
+      <div className="space-y-1">
+        <div className="flex justify-between text-xs">
+          <span className="text-slate-400">{label}</span>
+          <span className="text-slate-300 font-mono">{value}</span>
+        </div>
+        <input
+          type="range"
+          min={min}
+          max={max}
+          step={step}
+          value={value}
+          onChange={(e) => onChange(parseFloat(e.target.value))}
+          className="w-full h-1 bg-slate-600 rounded-lg appearance-none cursor-pointer accent-indigo-500"
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="absolute top-2 right-2 w-72 z-40 bg-slate-800 border border-slate-600 rounded-lg shadow-xl overflow-hidden">
+      {/* Header */}
+      <div className="flex items-center justify-between px-3 py-2 border-b border-slate-700">
+        <span className="text-sm font-medium">Display Settings</span>
+        <button onClick={onClose} className="p-1 hover:bg-slate-700 rounded">
+          <X className="w-3.5 h-3.5" />
+        </button>
+      </div>
+
+      <div className="max-h-[60vh] overflow-y-auto">
+        {/* Physics Section */}
+        <div className="border-b border-slate-700">
+          <button
+            onClick={() => setPhysicsOpen(!physicsOpen)}
+            className="w-full flex items-center justify-between px-3 py-2 text-xs uppercase text-slate-400 hover:bg-slate-700/50"
+          >
+            Physics
+            {physicsOpen ? <ChevronUp className="w-3 h-3" /> : <ChevronDown className="w-3 h-3" />}
+          </button>
+          {physicsOpen && (
+            <div className="px-3 pb-3 space-y-3">
+              {slider('Gravitational Constant', physics.gravitationalConstant, -200, -10, 5, (v) =>
+                onPhysicsChange({ ...physics, gravitationalConstant: v })
+              )}
+              {slider('Spring Length', physics.springLength, 50, 500, 10, (v) =>
+                onPhysicsChange({ ...physics, springLength: v })
+              )}
+              {slider('Spring Constant', physics.springConstant, 0.01, 0.5, 0.01, (v) =>
+                onPhysicsChange({ ...physics, springConstant: v })
+              )}
+              {slider('Damping', physics.damping, 0.1, 0.9, 0.05, (v) =>
+                onPhysicsChange({ ...physics, damping: v })
+              )}
+              {slider('Avoid Overlap', physics.avoidOverlap, 0, 1, 0.1, (v) =>
+                onPhysicsChange({ ...physics, avoidOverlap: v })
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* Style Section */}
+        <div>
+          <button
+            onClick={() => setStyleOpen(!styleOpen)}
+            className="w-full flex items-center justify-between px-3 py-2 text-xs uppercase text-slate-400 hover:bg-slate-700/50"
+          >
+            Styling
+            {styleOpen ? <ChevronUp className="w-3 h-3" /> : <ChevronDown className="w-3 h-3" />}
+          </button>
+          {styleOpen && (
+            <div className="px-3 pb-3 space-y-3">
+              {slider('Node Font Size', style.nodeFontSize, 6, 24, 1, (v) =>
+                onStyleChange({ ...style, nodeFontSize: v })
+              )}
+              {slider('Node Border Width', style.nodeBorderWidth, 1, 6, 1, (v) =>
+                onStyleChange({ ...style, nodeBorderWidth: v })
+              )}
+              <div className="space-y-1">
+                <span className="text-xs text-slate-400">Edge Smooth Type</span>
+                <select
+                  value={style.edgeSmoothType}
+                  onChange={(e) => onStyleChange({ ...style, edgeSmoothType: e.target.value })}
+                  className="w-full px-2 py-1 bg-slate-700 border border-slate-600 rounded text-sm"
+                >
+                  {SMOOTH_TYPES.map((t) => (
+                    <option key={t} value={t}>{t}</option>
+                  ))}
+                </select>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Footer */}
+      <div className="px-3 py-2 border-t border-slate-700">
+        <button
+          onClick={onReset}
+          className="w-full flex items-center justify-center gap-1.5 px-3 py-1.5 text-xs text-slate-300 bg-slate-700 hover:bg-slate-600 rounded transition-colors"
+        >
+          <RotateCcw className="w-3 h-3" />
+          Reset to Defaults
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/renderer/components/graph/GraphViewManager.tsx
+++ b/desktop/src/renderer/components/graph/GraphViewManager.tsx
@@ -1,0 +1,177 @@
+import { useState, useRef, useEffect } from 'react';
+import { Bookmark, Pencil, Trash2, Check, X } from 'lucide-react';
+import type { GraphView, GraphFilterState, GraphPhysicsSettings, GraphStyleSettings } from '../../../shared/types';
+
+interface GraphViewManagerProps {
+  views: GraphView[];
+  activeViewId?: string;
+  currentFilter: GraphFilterState;
+  currentPhysics: GraphPhysicsSettings;
+  currentStyle: GraphStyleSettings;
+  hiddenNodeIds: string[];
+  pinnedMemoryIds: string[];
+  onLoadView: (view: GraphView) => void;
+  onSave: (view: GraphView) => Promise<GraphView>;
+  onDelete: (id: string) => Promise<void>;
+}
+
+export default function GraphViewManager({
+  views, activeViewId, currentFilter, currentPhysics, currentStyle,
+  hiddenNodeIds, pinnedMemoryIds, onLoadView, onSave, onDelete,
+}: GraphViewManagerProps) {
+  const [open, setOpen] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [newName, setNewName] = useState('');
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editName, setEditName] = useState('');
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setOpen(false);
+        setSaving(false);
+        setEditingId(null);
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  async function handleSave() {
+    if (!newName.trim()) return;
+    const now = new Date().toISOString();
+    const view: GraphView = {
+      id: crypto.randomUUID(),
+      name: newName.trim(),
+      created_at: now,
+      updated_at: now,
+      filter: currentFilter,
+      physics: currentPhysics,
+      style: currentStyle,
+      hiddenNodeIds,
+      pinnedMemoryIds,
+    };
+    await onSave(view);
+    setNewName('');
+    setSaving(false);
+  }
+
+  async function handleRename(id: string) {
+    if (!editName.trim()) return;
+    const view = views.find((v) => v.id === id);
+    if (!view) return;
+    await onSave({ ...view, name: editName.trim() });
+    setEditingId(null);
+  }
+
+  return (
+    <div className="relative" ref={menuRef}>
+      <button
+        onClick={() => setOpen(!open)}
+        className={`px-3 py-1.5 rounded-lg text-sm flex items-center gap-2 transition-colors ${
+          activeViewId
+            ? 'bg-indigo-500/20 text-indigo-400 border border-indigo-500/50'
+            : 'bg-slate-800 text-slate-400 border border-slate-700'
+        }`}
+        title="Saved Views"
+      >
+        <Bookmark className="w-4 h-4" />
+        Views
+      </button>
+
+      {open && (
+        <div className="absolute right-0 top-full mt-1 w-64 bg-slate-700 border border-slate-600 rounded-lg shadow-xl z-50 overflow-hidden">
+          <div className="px-3 py-2 border-b border-slate-600 text-xs uppercase text-slate-400">
+            Saved Views
+          </div>
+
+          {views.length === 0 ? (
+            <div className="px-3 py-3 text-sm text-slate-500 text-center">No saved views</div>
+          ) : (
+            <div className="max-h-48 overflow-y-auto">
+              {views.map((view) => (
+                <div
+                  key={view.id}
+                  className={`group flex items-center px-3 py-2 hover:bg-slate-600/50 ${
+                    view.id === activeViewId ? 'bg-indigo-500/10' : ''
+                  }`}
+                >
+                  {editingId === view.id ? (
+                    <div className="flex-1 flex items-center gap-1">
+                      <input
+                        autoFocus
+                        value={editName}
+                        onChange={(e) => setEditName(e.target.value)}
+                        onKeyDown={(e) => { if (e.key === 'Enter') handleRename(view.id); if (e.key === 'Escape') setEditingId(null); }}
+                        className="flex-1 px-1.5 py-0.5 bg-slate-800 border border-slate-500 rounded text-sm"
+                      />
+                      <button onClick={() => handleRename(view.id)} className="p-0.5 hover:text-green-400">
+                        <Check className="w-3.5 h-3.5" />
+                      </button>
+                      <button onClick={() => setEditingId(null)} className="p-0.5 hover:text-red-400">
+                        <X className="w-3.5 h-3.5" />
+                      </button>
+                    </div>
+                  ) : (
+                    <>
+                      <button
+                        onClick={() => { onLoadView(view); setOpen(false); }}
+                        className="flex-1 text-left text-sm text-slate-200 truncate"
+                      >
+                        {view.id === activeViewId && <span className="text-indigo-400 mr-1">*</span>}
+                        {view.name}
+                      </button>
+                      <div className="hidden group-hover:flex items-center gap-0.5 ml-1">
+                        <button
+                          onClick={() => { setEditingId(view.id); setEditName(view.name); }}
+                          className="p-1 hover:text-blue-400"
+                        >
+                          <Pencil className="w-3 h-3" />
+                        </button>
+                        <button
+                          onClick={() => onDelete(view.id)}
+                          className="p-1 hover:text-red-400"
+                        >
+                          <Trash2 className="w-3 h-3" />
+                        </button>
+                      </div>
+                    </>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+
+          <div className="border-t border-slate-600">
+            {saving ? (
+              <div className="px-3 py-2 flex items-center gap-1">
+                <input
+                  autoFocus
+                  value={newName}
+                  onChange={(e) => setNewName(e.target.value)}
+                  onKeyDown={(e) => { if (e.key === 'Enter') handleSave(); if (e.key === 'Escape') setSaving(false); }}
+                  placeholder="View name..."
+                  className="flex-1 px-2 py-1 bg-slate-800 border border-slate-500 rounded text-sm"
+                />
+                <button onClick={handleSave} className="p-1 hover:text-green-400">
+                  <Check className="w-4 h-4" />
+                </button>
+                <button onClick={() => setSaving(false)} className="p-1 hover:text-red-400">
+                  <X className="w-4 h-4" />
+                </button>
+              </div>
+            ) : (
+              <button
+                onClick={() => setSaving(true)}
+                className="w-full px-3 py-2 text-sm text-slate-300 hover:bg-slate-600/50 text-left"
+              >
+                Save Current View...
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/desktop/src/renderer/hooks/useGraphSettings.ts
+++ b/desktop/src/renderer/hooks/useGraphSettings.ts
@@ -1,0 +1,70 @@
+import { useState, useCallback, useRef } from 'react';
+import type { GraphPhysicsSettings, GraphStyleSettings } from '../../shared/types';
+
+export const DEFAULT_PHYSICS: GraphPhysicsSettings = {
+  gravitationalConstant: -80,
+  centralGravity: 0.005,
+  springLength: 230,
+  springConstant: 0.08,
+  damping: 0.4,
+  avoidOverlap: 0.8,
+  maxVelocity: 30,
+  timestep: 0.35,
+};
+
+export const DEFAULT_STYLE: GraphStyleSettings = {
+  nodeFontSize: 12,
+  nodeBorderWidth: 2,
+  edgeFontSize: 10,
+  edgeSmoothType: 'dynamic',
+};
+
+export function useGraphSettings(networkRef: React.MutableRefObject<any>) {
+  const [physics, setPhysics] = useState<GraphPhysicsSettings>({ ...DEFAULT_PHYSICS });
+  const [style, setStyle] = useState<GraphStyleSettings>({ ...DEFAULT_STYLE });
+
+  const applyPhysics = useCallback((next: GraphPhysicsSettings) => {
+    setPhysics(next);
+    if (networkRef.current) {
+      networkRef.current.setOptions({
+        physics: {
+          enabled: true,
+          forceAtlas2Based: {
+            gravitationalConstant: next.gravitationalConstant,
+            centralGravity: next.centralGravity,
+            springLength: next.springLength,
+            springConstant: next.springConstant,
+            damping: next.damping,
+            avoidOverlap: next.avoidOverlap,
+          },
+          maxVelocity: next.maxVelocity,
+          timestep: next.timestep,
+        },
+      });
+      networkRef.current.stabilize(100);
+    }
+  }, [networkRef]);
+
+  const applyStyle = useCallback((next: GraphStyleSettings) => {
+    setStyle(next);
+    if (networkRef.current) {
+      networkRef.current.setOptions({
+        nodes: {
+          font: { size: next.nodeFontSize },
+          borderWidth: next.nodeBorderWidth,
+        },
+        edges: {
+          font: { size: next.edgeFontSize },
+          smooth: { type: next.edgeSmoothType },
+        },
+      });
+    }
+  }, [networkRef]);
+
+  const resetToDefaults = useCallback(() => {
+    applyPhysics({ ...DEFAULT_PHYSICS });
+    applyStyle({ ...DEFAULT_STYLE });
+  }, [applyPhysics, applyStyle]);
+
+  return { physics, style, applyPhysics, applyStyle, resetToDefaults };
+}

--- a/desktop/src/renderer/hooks/useGraphViews.ts
+++ b/desktop/src/renderer/hooks/useGraphViews.ts
@@ -1,0 +1,39 @@
+import { useState, useEffect, useCallback } from 'react';
+import type { GraphView } from '../../shared/types';
+
+export function useGraphViews() {
+  const [views, setViews] = useState<GraphView[]>([]);
+  const [activeViewId, setActiveViewId] = useState<string | undefined>();
+  const [loading, setLoading] = useState(true);
+
+  const refresh = useCallback(async () => {
+    try {
+      const list = await window.mycelicMemory.graphViews.list();
+      setViews(list);
+      const active = await window.mycelicMemory.graphViews.getActive();
+      setActiveViewId(active?.id);
+    } catch (err) {
+      console.error('Failed to load graph views:', err);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const saveView = useCallback(async (view: GraphView) => {
+    const saved = await window.mycelicMemory.graphViews.save(view);
+    await window.mycelicMemory.graphViews.setActive(saved.id);
+    await refresh();
+    return saved;
+  }, [refresh]);
+
+  const deleteView = useCallback(async (id: string) => {
+    await window.mycelicMemory.graphViews.delete(id);
+    await refresh();
+  }, [refresh]);
+
+  return { views, activeViewId, loading, refresh, saveView, deleteView };
+}

--- a/desktop/src/renderer/pages/KnowledgeGraph.tsx
+++ b/desktop/src/renderer/pages/KnowledgeGraph.tsx
@@ -1,7 +1,12 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import toast from 'react-hot-toast';
-import { Network, RefreshCw, ZoomIn, ZoomOut, Maximize2, MessageSquare, Layers, Eye, EyeOff } from 'lucide-react';
-import type { Memory, MemoryRelationship, ClaudeSession } from '../../shared/types';
+import { Network, RefreshCw, ZoomIn, ZoomOut, Maximize2, MessageSquare, Layers, Eye, EyeOff, Search, X, Settings2 } from 'lucide-react';
+import type { Memory, MemoryRelationship, ClaudeSession, GraphView, GraphFilterState } from '../../shared/types';
+import GraphContextMenu, { type ContextMenuAction } from '../components/graph/GraphContextMenu';
+import GraphDisplaySettings from '../components/graph/GraphDisplaySettings';
+import GraphViewManager from '../components/graph/GraphViewManager';
+import { useGraphSettings, DEFAULT_PHYSICS, DEFAULT_STYLE } from '../hooks/useGraphSettings';
+import { useGraphViews } from '../hooks/useGraphViews';
 
 // Note: vis-network types
 interface NetworkNode {
@@ -77,53 +82,54 @@ const SESSION_COLORS = [
 const SESSION_NODE_COLOR = '#f97316';
 const SOURCE_EDGE_COLOR = '#f97316';
 
-// Extracted as a stable constant — no need to recreate on every render
-const NETWORK_OPTIONS = {
-  nodes: {
-    font: { color: '#f1f5f9', size: 12 },
-    borderWidth: 2,
-    borderWidthSelected: 4,
-    scaling: {
-      label: {
-        enabled: true,
-        min: 8,
-        max: 20,
-        drawThreshold: 8,
-        maxVisible: 20,
+function buildNetworkOptions(physics: typeof DEFAULT_PHYSICS, style: typeof DEFAULT_STYLE) {
+  return {
+    nodes: {
+      font: { color: '#f1f5f9', size: style.nodeFontSize },
+      borderWidth: style.nodeBorderWidth,
+      borderWidthSelected: 4,
+      scaling: {
+        label: {
+          enabled: true,
+          min: 8,
+          max: 20,
+          drawThreshold: 8,
+          maxVisible: 20,
+        },
       },
     },
-  },
-  edges: {
-    font: { color: '#94a3b8', size: 10, strokeWidth: 0 },
-    smooth: { type: 'dynamic' as const },
-  },
-  physics: {
-    enabled: true,
-    forceAtlas2Based: {
-      gravitationalConstant: -80,
-      centralGravity: 0.005,
-      springLength: 230,
-      springConstant: 0.08,
-      damping: 0.4,
-      avoidOverlap: 0.8,
+    edges: {
+      font: { color: '#94a3b8', size: style.edgeFontSize, strokeWidth: 0 },
+      smooth: { type: style.edgeSmoothType as any },
     },
-    stabilization: {
+    physics: {
       enabled: true,
-      iterations: 300,
-      updateInterval: 25,
-      fit: true,
+      forceAtlas2Based: {
+        gravitationalConstant: physics.gravitationalConstant,
+        centralGravity: physics.centralGravity,
+        springLength: physics.springLength,
+        springConstant: physics.springConstant,
+        damping: physics.damping,
+        avoidOverlap: physics.avoidOverlap,
+      },
+      stabilization: {
+        enabled: true,
+        iterations: 300,
+        updateInterval: 25,
+        fit: true,
+      },
+      maxVelocity: physics.maxVelocity,
+      minVelocity: 0.1,
+      timestep: physics.timestep,
     },
-    maxVelocity: 30,
-    minVelocity: 0.1,
-    timestep: 0.35,
-  },
-  interaction: {
-    hover: true,
-    tooltipDelay: 200,
-    zoomView: true,
-    dragView: true,
-  },
-};
+    interaction: {
+      hover: true,
+      tooltipDelay: 200,
+      zoomView: true,
+      dragView: true,
+    },
+  };
+}
 
 type SelectedItem =
   | { type: 'memory'; data: Memory }
@@ -157,9 +163,27 @@ export default function KnowledgeGraph() {
     domain: '',
     relationshipType: '',
   });
+  const [searchQuery, setSearchQuery] = useState('');
+  const [renderedCounts, setRenderedCounts] = useState({ nodes: 0, edges: 0 });
+
+  // New state for context menu, hidden/pinned nodes, display settings
+  const [contextMenu, setContextMenu] = useState<{
+    x: number; y: number; nodeId: string | null; nodeType: 'memory' | 'session' | null;
+  } | null>(null);
+  const [hiddenNodeIds, setHiddenNodeIds] = useState<Set<string>>(new Set());
+  const [pinnedMemoryIds, setPinnedMemoryIds] = useState<Set<string>>(new Set());
+  const [showDisplaySettings, setShowDisplaySettings] = useState(false);
+
+  // Hooks
+  const { physics, style, applyPhysics, applyStyle, resetToDefaults } = useGraphSettings(networkRef);
+  const { views, activeViewId, saveView, deleteView } = useGraphViews();
 
   // Keep refs in sync so event handlers always see current data
   useEffect(() => { memoriesRef.current = memories; }, [memories]);
+
+  // Ref for hiddenNodeIds so context menu handler always sees current value
+  const hiddenNodeIdsRef = useRef(hiddenNodeIds);
+  useEffect(() => { hiddenNodeIdsRef.current = hiddenNodeIds; }, [hiddenNodeIds]);
 
   // Memoize render-phase computations (previously recomputed every render)
   const domains = useMemo(
@@ -255,6 +279,50 @@ export default function KnowledgeGraph() {
     }
   }
 
+  function handleSearch(query: string) {
+    setSearchQuery(query);
+    if (!networkRef.current || !nodesDataSetRef.current) return;
+
+    const nodesDS = nodesDataSetRef.current;
+
+    if (!query.trim()) {
+      // Clear search — restore all nodes to full opacity
+      const updates: { id: string; opacity: number }[] = [];
+      nodesDS.forEach((node: NetworkNode) => {
+        updates.push({ id: node.id, opacity: 1.0 });
+      });
+      if (updates.length > 0) nodesDS.update(updates);
+      return;
+    }
+
+    const lowerQuery = query.toLowerCase();
+    const matchingIds = new Set<string>();
+    memoriesRef.current.forEach((m) => {
+      if (
+        m.content.toLowerCase().includes(lowerQuery) ||
+        (m.domain || '').toLowerCase().includes(lowerQuery) ||
+        (m.tags || []).some((t) => t.toLowerCase().includes(lowerQuery))
+      ) {
+        matchingIds.add(m.id);
+      }
+    });
+
+    // Dim non-matching, highlight matching
+    const updates: { id: string; opacity: number }[] = [];
+    nodesDS.forEach((node: NetworkNode) => {
+      updates.push({
+        id: node.id,
+        opacity: matchingIds.has(node.id) ? 1.0 : 0.15,
+      });
+    });
+    if (updates.length > 0) nodesDS.update(updates);
+
+    // Focus camera on first match
+    if (matchingIds.size > 0 && matchingIds.size <= 20) {
+      networkRef.current.fit({ nodes: Array.from(matchingIds), animation: true });
+    }
+  }
+
   // Pure computation: build nodes + edges from current state
   const buildGraphData = useCallback(() => {
     let filteredMemories = [...memories];
@@ -296,6 +364,14 @@ export default function KnowledgeGraph() {
       filteredMemories = filteredMemories.filter((m) => connectedNodeIds.has(m.id));
     }
 
+    // Hidden nodes filter
+    if (hiddenNodeIds.size > 0) {
+      filteredMemories = filteredMemories.filter((m) => !hiddenNodeIds.has(m.id));
+      filteredRelationships = filteredRelationships.filter(
+        (r) => !hiddenNodeIds.has(r.source_memory_id) && !hiddenNodeIds.has(r.target_memory_id)
+      );
+    }
+
     // Build memory nodes
     const nodes: NetworkNode[] = filteredMemories.map((memory) => {
       const isSessionSummary = memory.source === 'claude-code-session';
@@ -305,10 +381,20 @@ export default function KnowledgeGraph() {
       const domainColor = DOMAIN_COLORS[memory.domain || 'general'] || DOMAIN_COLORS.general;
       const bgColor = isSessionSummary ? SESSION_NODE_COLOR : domainColor;
 
+      const contentPreview = memory.content.length > 120
+        ? memory.content.substring(0, 120) + '...'
+        : memory.content;
+      const tooltip = [
+        `[${memory.domain || 'general'}] importance: ${memory.importance}/10`,
+        `connections: ${degree}`,
+        '',
+        contentPreview,
+      ].join('\n');
+
       return {
         id: memory.id,
         label: memory.content.substring(0, 20) + (memory.content.length > 20 ? '...' : ''),
-        title: memory.content,
+        title: tooltip,
         color: {
           background: bgColor,
           border: isSessionSummary ? '#ea580c' : '#1e293b',
@@ -330,7 +416,7 @@ export default function KnowledgeGraph() {
       let colorIdx = 0;
 
       sessions.forEach((s) => {
-        if (referencedSessionIds.has(s.id)) {
+        if (referencedSessionIds.has(s.id) && !hiddenNodeIds.has(`session:${s.id}`)) {
           sessionNodeMap.set(s.id, s);
           if (!projectColors.has(s.project_hash)) {
             projectColors.set(s.project_hash, SESSION_COLORS[colorIdx % SESSION_COLORS.length]);
@@ -368,10 +454,10 @@ export default function KnowledgeGraph() {
         id: rel.id,
         from: rel.source_memory_id,
         to: rel.target_memory_id,
-        title: rel.relationship_type,
+        title: `${rel.relationship_type} (strength: ${(rel.strength || 0.5).toFixed(2)})`,
         color: { color: edgeColor, opacity, hover: edgeColor },
-        width: 0.8,
-        hoverWidth: 2,
+        width: 0.5 + (rel.strength || 0.5) * 2.5,
+        hoverWidth: 3,
         arrows: { to: { enabled: true, scaleFactor: 0.5 } },
       };
     });
@@ -394,7 +480,7 @@ export default function KnowledgeGraph() {
     }
 
     return { nodes, edges, sessionNodeMap, filteredMemories };
-  }, [memories, relationships, sessions, filter, showSessions, showOrphans]);
+  }, [memories, relationships, sessions, filter, showSessions, showOrphans, hiddenNodeIds]);
 
   // Fix 2: Register event handlers ONCE — uses refs for current data, not closures over stale state
   const registerEventHandlers = useCallback((network: any) => {
@@ -412,6 +498,29 @@ export default function KnowledgeGraph() {
       setTimeout(() => {
         network.setOptions({ physics: { enabled: false } });
       }, 1500);
+    });
+
+    // Context menu on right-click
+    network.on('oncontext', (params: { event: MouseEvent; pointer: { DOM: { x: number; y: number } } }) => {
+      params.event.preventDefault();
+      const nodeId = network.getNodeAt(params.pointer.DOM) as string | undefined;
+      let nodeType: 'memory' | 'session' | null = null;
+      let resolvedNodeId: string | null = nodeId ?? null;
+
+      if (nodeId) {
+        nodeType = nodeId.startsWith('session:') ? 'session' : 'memory';
+      }
+
+      // Use the container's bounding rect to get viewport-relative coords
+      const container = network.body.container as HTMLElement;
+      const rect = container.getBoundingClientRect();
+
+      setContextMenu({
+        x: rect.left + params.pointer.DOM.x,
+        y: rect.top + params.pointer.DOM.y,
+        nodeId: resolvedNodeId,
+        nodeType,
+      });
     });
 
     // Fix 3: Smart hover diffing — only update the delta between previous and current hover state
@@ -529,6 +638,7 @@ export default function KnowledgeGraph() {
       const vis = visModuleRef.current;
       const { nodes, edges, sessionNodeMap, filteredMemories } = buildGraphData();
       sessionNodeMapRef.current = sessionNodeMap;
+      setRenderedCounts({ nodes: nodes.length, edges: edges.length });
 
       if (!networkRef.current) {
         // FIRST TIME: create network + DataSets + register all event handlers once
@@ -537,10 +647,11 @@ export default function KnowledgeGraph() {
         nodesDataSetRef.current = nodesDS;
         edgesDataSetRef.current = edgesDS;
 
+        const initialOptions = buildNetworkOptions(physics, style);
         networkRef.current = new vis.Network(
           containerRef.current!,
           { nodes: nodesDS, edges: edgesDS },
-          NETWORK_OPTIONS
+          initialOptions
         );
         registerEventHandlers(networkRef.current);
       } else {
@@ -591,7 +702,7 @@ export default function KnowledgeGraph() {
     })();
 
     return () => { cancelled = true; };
-  }, [memories, relationships, sessions, filter, showSessions, showOrphans, clustered, buildGraphData, registerEventHandlers]);
+  }, [memories, relationships, sessions, filter, showSessions, showOrphans, clustered, hiddenNodeIds, buildGraphData, registerEventHandlers]);
 
   // Cleanup on unmount only — network is never destroyed mid-lifecycle
   useEffect(() => {
@@ -623,6 +734,129 @@ export default function KnowledgeGraph() {
     }
   }
 
+  // Context menu action handler
+  function handleContextMenuAction(action: ContextMenuAction) {
+    if (!contextMenu) return;
+    const { nodeId } = contextMenu;
+
+    switch (action) {
+      case 'focus-neighborhood': {
+        if (!nodeId || !networkRef.current) break;
+        const connected = networkRef.current.getConnectedNodes(nodeId) as string[];
+        networkRef.current.fit({ nodes: [nodeId, ...connected], animation: true });
+        break;
+      }
+      case 'show-only-connected': {
+        if (!nodeId || !networkRef.current) break;
+        const connected = new Set(networkRef.current.getConnectedNodes(nodeId) as string[]);
+        connected.add(nodeId);
+        // Hide everything not connected
+        const toHide = new Set(hiddenNodeIds);
+        memoriesRef.current.forEach((m) => {
+          if (!connected.has(m.id)) toHide.add(m.id);
+        });
+        setHiddenNodeIds(toHide);
+        break;
+      }
+      case 'hide-node': {
+        if (!nodeId) break;
+        setHiddenNodeIds((prev) => new Set(prev).add(nodeId));
+        toast.success('Node hidden');
+        break;
+      }
+      case 'pin-to-view': {
+        if (!nodeId) break;
+        setPinnedMemoryIds((prev) => new Set(prev).add(nodeId));
+        toast.success('Node pinned to view');
+        break;
+      }
+      case 'unpin-from-view': {
+        if (!nodeId) break;
+        setPinnedMemoryIds((prev) => {
+          const next = new Set(prev);
+          next.delete(nodeId);
+          return next;
+        });
+        toast.success('Node unpinned');
+        break;
+      }
+      case 'copy-content': {
+        if (!nodeId) break;
+        const mem = memoriesRef.current.find((m) => m.id === nodeId);
+        if (mem) {
+          navigator.clipboard.writeText(mem.content);
+          toast.success('Content copied');
+        }
+        break;
+      }
+      case 'copy-id': {
+        if (!nodeId) break;
+        const rawId = nodeId.startsWith('session:') ? nodeId.replace('session:', '') : nodeId;
+        navigator.clipboard.writeText(rawId);
+        toast.success('ID copied');
+        break;
+      }
+      case 'show-all-hidden': {
+        setHiddenNodeIds(new Set());
+        toast.success('All hidden nodes restored');
+        break;
+      }
+      case 'reset-view': {
+        setHiddenNodeIds(new Set());
+        setPinnedMemoryIds(new Set());
+        setFilter({ domain: '', relationshipType: '' });
+        setSearchQuery('');
+        handleSearch('');
+        resetToDefaults();
+        toast.success('View reset');
+        break;
+      }
+      case 'fit-all': {
+        handleFit();
+        break;
+      }
+    }
+    setContextMenu(null);
+  }
+
+  // Load a saved view
+  function handleLoadView(view: GraphView) {
+    // Restore filters
+    setFilter({
+      domain: view.filter.domain,
+      relationshipType: view.filter.relationshipType,
+    });
+    setSearchQuery(view.filter.searchQuery);
+    setShowSessions(view.filter.showSessions);
+    setShowOrphans(view.filter.showOrphans);
+    setClustered(view.filter.clustered);
+
+    // Restore hidden/pinned
+    setHiddenNodeIds(new Set(view.hiddenNodeIds || []));
+    setPinnedMemoryIds(new Set(view.pinnedMemoryIds || []));
+
+    // Restore physics/style
+    applyPhysics(view.physics);
+    applyStyle(view.style);
+
+    // Apply search highlight after a tick (needs nodesDS to be populated)
+    if (view.filter.searchQuery) {
+      setTimeout(() => handleSearch(view.filter.searchQuery), 100);
+    }
+
+    toast.success(`Loaded view: ${view.name}`);
+  }
+
+  // Current filter state for view saving
+  const currentFilterState: GraphFilterState = {
+    domain: filter.domain,
+    relationshipType: filter.relationshipType,
+    searchQuery,
+    showSessions,
+    showOrphans,
+    clustered,
+  };
+
   return (
     <div className="h-screen flex flex-col bg-slate-900">
       {/* Toolbar */}
@@ -630,11 +864,28 @@ export default function KnowledgeGraph() {
         <div className="flex items-center gap-4">
           <h1 className="text-xl font-semibold">Knowledge Graph</h1>
           <span className="text-sm text-slate-400">
-            {memories.length} memories
-            {sessionNodeCount > 0 && ` + ${sessionNodeCount} chats`}
-            {` \u2022 ${relationships.length} connections`}
-            {linkedCount > 0 && ` \u2022 ${linkedCount} traced`}
+            {renderedCounts.nodes} nodes &bull; {renderedCounts.edges} edges
+            {renderedCounts.nodes !== memories.length && ` (${memories.length} total)`}
+            {hiddenNodeIds.size > 0 && ` \u2022 ${hiddenNodeIds.size} hidden`}
           </span>
+          <div className="relative">
+            <Search className="w-3.5 h-3.5 absolute left-2.5 top-1/2 -translate-y-1/2 text-slate-500" />
+            <input
+              type="text"
+              value={searchQuery}
+              onChange={(e) => handleSearch(e.target.value)}
+              placeholder="Search nodes..."
+              className="pl-8 pr-7 py-1.5 w-44 bg-slate-800 border border-slate-700 rounded-lg text-sm placeholder:text-slate-500 focus:outline-none focus:border-slate-500"
+            />
+            {searchQuery && (
+              <button
+                onClick={() => handleSearch('')}
+                className="absolute right-2 top-1/2 -translate-y-1/2 text-slate-500 hover:text-slate-300"
+              >
+                <X className="w-3.5 h-3.5" />
+              </button>
+            )}
+          </div>
         </div>
         <div className="flex items-center gap-2">
           {/* Filters */}
@@ -742,6 +993,33 @@ export default function KnowledgeGraph() {
             <RefreshCw className={`w-4 h-4 ${discovering ? 'animate-spin' : ''}`} />
             Discover
           </button>
+
+          {/* Display Settings Toggle */}
+          <button
+            onClick={() => setShowDisplaySettings(!showDisplaySettings)}
+            className={`p-2 rounded-lg transition-colors ${
+              showDisplaySettings
+                ? 'bg-indigo-500/20 text-indigo-400'
+                : 'hover:bg-slate-700'
+            }`}
+            title="Display Settings"
+          >
+            <Settings2 className="w-4 h-4" />
+          </button>
+
+          {/* View Manager */}
+          <GraphViewManager
+            views={views}
+            activeViewId={activeViewId}
+            currentFilter={currentFilterState}
+            currentPhysics={physics}
+            currentStyle={style}
+            hiddenNodeIds={Array.from(hiddenNodeIds)}
+            pinnedMemoryIds={Array.from(pinnedMemoryIds)}
+            onLoadView={handleLoadView}
+            onSave={saveView}
+            onDelete={deleteView}
+          />
         </div>
       </div>
 
@@ -762,6 +1040,32 @@ export default function KnowledgeGraph() {
             </div>
           ) : (
             <div ref={containerRef} className="w-full h-full" />
+          )}
+
+          {/* Display Settings Panel */}
+          {showDisplaySettings && (
+            <GraphDisplaySettings
+              physics={physics}
+              style={style}
+              onPhysicsChange={applyPhysics}
+              onStyleChange={applyStyle}
+              onReset={resetToDefaults}
+              onClose={() => setShowDisplaySettings(false)}
+            />
+          )}
+
+          {/* Context Menu */}
+          {contextMenu && (
+            <GraphContextMenu
+              x={contextMenu.x}
+              y={contextMenu.y}
+              nodeId={contextMenu.nodeId}
+              nodeType={contextMenu.nodeType}
+              isPinned={contextMenu.nodeId ? pinnedMemoryIds.has(contextMenu.nodeId) : false}
+              hiddenCount={hiddenNodeIds.size}
+              onAction={handleContextMenuAction}
+              onClose={() => setContextMenu(null)}
+            />
           )}
         </div>
 

--- a/desktop/src/shared/types.ts
+++ b/desktop/src/shared/types.ts
@@ -393,4 +393,61 @@ export type IPCChannels = {
   'services:start-ollama': { params: void; result: boolean };
   'services:start-qdrant': { params: void; result: boolean };
   'services:stop-backend': { params: void; result: boolean };
+
+  // Graph views
+  'graph-views:list': { params: void; result: GraphView[] };
+  'graph-views:get': { params: { id: string }; result: GraphView | null };
+  'graph-views:save': { params: GraphView; result: GraphView };
+  'graph-views:delete': { params: { id: string }; result: boolean };
+  'graph-views:set-active': { params: { id: string | null }; result: boolean };
+  'graph-views:get-active': { params: void; result: GraphView | null };
 };
+
+// =============================================================================
+// GRAPH VIEW TYPES (Knowledge Graph display settings & saved views)
+// =============================================================================
+
+export interface GraphPhysicsSettings {
+  gravitationalConstant: number;
+  centralGravity: number;
+  springLength: number;
+  springConstant: number;
+  damping: number;
+  avoidOverlap: number;
+  maxVelocity: number;
+  timestep: number;
+}
+
+export interface GraphStyleSettings {
+  nodeFontSize: number;
+  nodeBorderWidth: number;
+  edgeFontSize: number;
+  edgeSmoothType: string;
+}
+
+export interface GraphFilterState {
+  domain: string;
+  relationshipType: string;
+  searchQuery: string;
+  showSessions: boolean;
+  showOrphans: boolean;
+  clustered: boolean;
+}
+
+export interface GraphView {
+  id: string;
+  name: string;
+  description?: string;
+  created_at: string;
+  updated_at: string;
+  filter: GraphFilterState;
+  physics: GraphPhysicsSettings;
+  style: GraphStyleSettings;
+  pinnedMemoryIds?: string[];
+  hiddenNodeIds?: string[];
+}
+
+export interface GraphViewStore {
+  views: GraphView[];
+  activeViewId?: string;
+}


### PR DESCRIPTION
## Summary
- Right-click context menu on graph nodes (focus neighborhood, hide, pin, copy content/ID) and background (show all hidden, reset view, fit all)
- Configurable display settings panel with live physics sliders (gravity, springs, damping) and style controls (font size, border width, edge smooth type)
- Saveable/loadable graph views that persist filter state, physics, style, hidden nodes, and pinned nodes via electron-store

## Test plan
- [ ] Right-click a memory node — context menu appears with 6 actions
- [ ] Right-click background — context menu shows reset/fit/show hidden actions
- [ ] Open Display Settings (gear icon) — drag sliders, observe real-time layout changes
- [ ] Save a view, close dropdown, reopen — view persists
- [ ] Load a saved view — all state (filters, physics, hidden nodes) restores correctly
- [ ] TypeScript: `npx tsc --noEmit --skipLibCheck -p tsconfig.main.json` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)