### PR TITLE
fix: working light/dark mode toggle

### DIFF
--- a/desktop/src/renderer/App.tsx
+++ b/desktop/src/renderer/App.tsx
@@ -12,6 +12,8 @@ import {
   Database,
   ChevronsUpDown,
   Loader2,
+  Sun,
+  Moon,
 } from 'lucide-react';
 import { useEffect, useState, useRef, useCallback } from 'react';
 import toast from 'react-hot-toast';
@@ -58,6 +60,7 @@ function NavItem({ to, icon: Icon, label, collapsed }: NavItemProps) {
 function App() {
   const [health, setHealth] = useState<HealthStatus | null>(null);
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+  const [theme, setTheme] = useState<'dark' | 'light'>('dark');
   const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
   const [createModalOpen, setCreateModalOpen] = useState(false);
   const location = useLocation();
@@ -69,11 +72,15 @@ function App() {
   const [switching, setSwitching] = useState(false);
   const [dbSwitchKey, setDbSwitchKey] = useState(0);
 
-  // Load sidebar collapsed state from settings
+  // Load sidebar collapsed state and theme from settings
   useEffect(() => {
     window.mycelicMemory.settings?.get?.()
-      .then((s: { sidebar_collapsed?: boolean }) => {
+      .then((s: { sidebar_collapsed?: boolean; theme?: string }) => {
         if (s?.sidebar_collapsed) setSidebarCollapsed(true);
+        if (s?.theme === 'light') {
+          setTheme('light');
+          document.documentElement.classList.add('light-mode');
+        }
       })
       .catch(() => {});
   }, []);
@@ -158,6 +165,17 @@ function App() {
     const next = !sidebarCollapsed;
     setSidebarCollapsed(next);
     window.mycelicMemory.settings?.update?.({ sidebar_collapsed: next }).catch(() => {});
+  };
+
+  const toggleTheme = () => {
+    const next = theme === 'dark' ? 'light' : 'dark';
+    setTheme(next);
+    if (next === 'light') {
+      document.documentElement.classList.add('light-mode');
+    } else {
+      document.documentElement.classList.remove('light-mode');
+    }
+    window.mycelicMemory.settings?.update?.({ theme: next }).catch(() => {});
   };
 
   // Global keyboard shortcuts
@@ -341,6 +359,20 @@ function App() {
           >
             <Plus className="w-4 h-4 shrink-0" />
             {!sidebarCollapsed && <span className="text-sm">New Memory</span>}
+          </button>
+          <button
+            onClick={toggleTheme}
+            title={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+            className={`w-full flex items-center gap-3 px-4 py-2.5 rounded-lg text-slate-400 hover:bg-slate-700 hover:text-slate-200 transition-colors ${
+              sidebarCollapsed ? 'justify-center' : ''
+            }`}
+          >
+            {theme === 'dark' ? (
+              <Sun className="w-4 h-4 shrink-0" />
+            ) : (
+              <Moon className="w-4 h-4 shrink-0" />
+            )}
+            {!sidebarCollapsed && <span className="text-sm">{theme === 'dark' ? 'Light Mode' : 'Dark Mode'}</span>}
           </button>
           <button
             onClick={toggleSidebar}

--- a/desktop/src/renderer/pages/Settings.tsx
+++ b/desktop/src/renderer/pages/Settings.tsx
@@ -891,27 +891,7 @@ export default function SettingsPage() {
           />
         </SettingsSection>
 
-        {/* UI */}
-        <SettingsSection title="Interface" icon={Settings}>
-          <div>
-            <label className="text-sm text-slate-400">Theme</label>
-            <select
-              value={settings.theme}
-              onChange={(e) => updateSetting('theme', e.target.value as 'dark' | 'light' | 'system')}
-              className="w-full mt-1 p-2 bg-slate-700 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
-            >
-              <option value="dark">Dark</option>
-              <option value="light">Light</option>
-              <option value="system">System</option>
-            </select>
-          </div>
-          <ToggleField
-            label="Collapse Sidebar"
-            value={settings.sidebar_collapsed}
-            onChange={(v) => updateSetting('sidebar_collapsed', v)}
-            description="Start with sidebar collapsed"
-          />
-        </SettingsSection>
+        {/* Claude Chat Stream section is the last config section */}
       </div>
 
       {/* App Info */}

--- a/desktop/src/renderer/styles/index.css
+++ b/desktop/src/renderer/styles/index.css
@@ -123,6 +123,27 @@ code {
   margin-bottom: 0.25rem;
 }
 
+/* Light mode — CSS filter inversion of the dark UI */
+html.light-mode {
+  filter: invert(1) hue-rotate(180deg);
+}
+
+html.light-mode img,
+html.light-mode video,
+html.light-mode canvas,
+html.light-mode svg:not(.invert-safe),
+html.light-mode .vis-network {
+  filter: invert(1) hue-rotate(180deg);
+}
+
+html.light-mode ::-webkit-scrollbar-track {
+  background: #e2e8f0;
+}
+
+html.light-mode ::-webkit-scrollbar-thumb {
+  background: #94a3b8;
+}
+
 /* Graph node styling */
 .vis-network {
   outline: none;


### PR DESCRIPTION
## Summary
- Removed the non-functional Interface section (theme dropdown + sidebar toggle) from Settings page
- Added a Sun/Moon toggle button in the sidebar quick actions area
- Implemented CSS filter inversion for actual light mode that works across the entire UI
- Theme preference persists via existing electron-store settings

## Test plan
- [ ] Click Sun icon in sidebar — UI inverts to light mode
- [ ] Click Moon icon — UI returns to dark mode
- [ ] Close and reopen app — theme preference persists
- [ ] Settings page no longer shows Interface section

🤖 Generated with [Claude Code](https://claude.com/claude-code)