### PR TITLE
fix: real-time physics settings in Knowledge Graph

### DIFF
--- a/desktop/src/renderer/components/graph/GraphDisplaySettings.tsx
+++ b/desktop/src/renderer/components/graph/GraphDisplaySettings.tsx
@@ -71,6 +71,9 @@ export default function GraphDisplaySettings({
               {slider('Gravitational Constant', physics.gravitationalConstant, -200, -10, 5, (v) =>
                 onPhysicsChange({ ...physics, gravitationalConstant: v })
               )}
+              {slider('Central Gravity', physics.centralGravity, 0, 0.1, 0.005, (v) =>
+                onPhysicsChange({ ...physics, centralGravity: v })
+              )}
               {slider('Spring Length', physics.springLength, 50, 500, 10, (v) =>
                 onPhysicsChange({ ...physics, springLength: v })
               )}
@@ -82,6 +85,9 @@ export default function GraphDisplaySettings({
               )}
               {slider('Avoid Overlap', physics.avoidOverlap, 0, 1, 0.1, (v) =>
                 onPhysicsChange({ ...physics, avoidOverlap: v })
+              )}
+              {slider('Max Velocity', physics.maxVelocity, 5, 100, 5, (v) =>
+                onPhysicsChange({ ...physics, maxVelocity: v })
               )}
             </div>
           )}

--- a/desktop/src/renderer/hooks/useGraphSettings.ts
+++ b/desktop/src/renderer/hooks/useGraphSettings.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef } from 'react';
+import { useState, useCallback, useRef, useEffect } from 'react';
 import type { GraphPhysicsSettings, GraphStyleSettings } from '../../shared/types';
 
 export const DEFAULT_PHYSICS: GraphPhysicsSettings = {
@@ -22,43 +22,50 @@ export const DEFAULT_STYLE: GraphStyleSettings = {
 export function useGraphSettings(networkRef: React.MutableRefObject<any>) {
   const [physics, setPhysics] = useState<GraphPhysicsSettings>({ ...DEFAULT_PHYSICS });
   const [style, setStyle] = useState<GraphStyleSettings>({ ...DEFAULT_STYLE });
+  const [tuning, setTuning] = useState(false);
+
+  // Expose tuning flag via ref so event handlers (registered once) can read it
+  const tuningRef = useRef(false);
+  useEffect(() => { tuningRef.current = tuning; }, [tuning]);
 
   const applyPhysics = useCallback((next: GraphPhysicsSettings) => {
     setPhysics(next);
-    if (networkRef.current) {
-      networkRef.current.setOptions({
-        physics: {
-          enabled: true,
-          forceAtlas2Based: {
-            gravitationalConstant: next.gravitationalConstant,
-            centralGravity: next.centralGravity,
-            springLength: next.springLength,
-            springConstant: next.springConstant,
-            damping: next.damping,
-            avoidOverlap: next.avoidOverlap,
-          },
-          maxVelocity: next.maxVelocity,
-          timestep: next.timestep,
+    if (!networkRef.current) return;
+
+    // Apply new physics options — keep physics enabled, don't call stabilize()
+    // The network will continuously simulate with the new parameters
+    networkRef.current.setOptions({
+      physics: {
+        enabled: true,
+        forceAtlas2Based: {
+          gravitationalConstant: next.gravitationalConstant,
+          centralGravity: next.centralGravity,
+          springLength: next.springLength,
+          springConstant: next.springConstant,
+          damping: next.damping,
+          avoidOverlap: next.avoidOverlap,
         },
-      });
-      networkRef.current.stabilize(100);
-    }
+        maxVelocity: next.maxVelocity,
+        timestep: next.timestep,
+        stabilization: false,
+      },
+    });
   }, [networkRef]);
 
   const applyStyle = useCallback((next: GraphStyleSettings) => {
     setStyle(next);
-    if (networkRef.current) {
-      networkRef.current.setOptions({
-        nodes: {
-          font: { size: next.nodeFontSize },
-          borderWidth: next.nodeBorderWidth,
-        },
-        edges: {
-          font: { size: next.edgeFontSize },
-          smooth: { type: next.edgeSmoothType },
-        },
-      });
-    }
+    if (!networkRef.current) return;
+
+    networkRef.current.setOptions({
+      nodes: {
+        font: { size: next.nodeFontSize },
+        borderWidth: next.nodeBorderWidth,
+      },
+      edges: {
+        font: { size: next.edgeFontSize },
+        smooth: { type: next.edgeSmoothType },
+      },
+    });
   }, [networkRef]);
 
   const resetToDefaults = useCallback(() => {
@@ -66,5 +73,17 @@ export function useGraphSettings(networkRef: React.MutableRefObject<any>) {
     applyStyle({ ...DEFAULT_STYLE });
   }, [applyPhysics, applyStyle]);
 
-  return { physics, style, applyPhysics, applyStyle, resetToDefaults };
+  // When tuning stops (settings panel closes), freeze physics after a settle period
+  useEffect(() => {
+    if (!tuning && networkRef.current) {
+      const timer = setTimeout(() => {
+        if (!tuningRef.current && networkRef.current) {
+          networkRef.current.setOptions({ physics: { enabled: false } });
+        }
+      }, 2000);
+      return () => clearTimeout(timer);
+    }
+  }, [tuning, networkRef]);
+
+  return { physics, style, tuning, setTuning, tuningRef, applyPhysics, applyStyle, resetToDefaults };
 }

--- a/desktop/src/renderer/pages/KnowledgeGraph.tsx
+++ b/desktop/src/renderer/pages/KnowledgeGraph.tsx
@@ -175,7 +175,7 @@ export default function KnowledgeGraph() {
   const [showDisplaySettings, setShowDisplaySettings] = useState(false);
 
   // Hooks
-  const { physics, style, applyPhysics, applyStyle, resetToDefaults } = useGraphSettings(networkRef);
+  const { physics, style, tuning, setTuning, tuningRef, applyPhysics, applyStyle, resetToDefaults } = useGraphSettings(networkRef);
   const { views, activeViewId, saveView, deleteView } = useGraphViews();
 
   // Keep refs in sync so event handlers always see current data
@@ -484,8 +484,9 @@ export default function KnowledgeGraph() {
 
   // Fix 2: Register event handlers ONCE — uses refs for current data, not closures over stale state
   const registerEventHandlers = useCallback((network: any) => {
-    // Stabilize-then-freeze
+    // Stabilize-then-freeze (skip freeze while user is tuning physics sliders)
     network.on('stabilizationIterationsDone', () => {
+      if (tuningRef.current) return;
       network.setOptions({ physics: { enabled: false } });
       network.fit();
     });
@@ -496,7 +497,9 @@ export default function KnowledgeGraph() {
 
     network.on('dragEnd', () => {
       setTimeout(() => {
-        network.setOptions({ physics: { enabled: false } });
+        if (!tuningRef.current) {
+          network.setOptions({ physics: { enabled: false } });
+        }
       }, 1500);
     });
 
@@ -996,7 +999,11 @@ export default function KnowledgeGraph() {
 
           {/* Display Settings Toggle */}
           <button
-            onClick={() => setShowDisplaySettings(!showDisplaySettings)}
+            onClick={() => {
+              const next = !showDisplaySettings;
+              setShowDisplaySettings(next);
+              setTuning(next);
+            }}
             className={`p-2 rounded-lg transition-colors ${
               showDisplaySettings
                 ? 'bg-indigo-500/20 text-indigo-400'
@@ -1050,7 +1057,7 @@ export default function KnowledgeGraph() {
               onPhysicsChange={applyPhysics}
               onStyleChange={applyStyle}
               onReset={resetToDefaults}
-              onClose={() => setShowDisplaySettings(false)}
+              onClose={() => { setShowDisplaySettings(false); setTuning(false); }}
             />
           )}
 


### PR DESCRIPTION
## Summary
- Physics sliders now update the graph continuously in real time while the settings panel is open
- Added Central Gravity and Max Velocity sliders
- Physics simulation stays alive during tuning, auto-freezes 2s after panel closes

## Test plan
- [ ] Open Display Settings (gear icon) — drag Spring Length slider — nodes spread/contract in real time
- [ ] Close panel — after 2s physics freezes and layout stabilizes
- [ ] Drag nodes while panel is open — physics stays active

🤖 Generated with [Claude Code](https://claude.com/claude-code)