### PR TITLE
fix: physics sliders now update graph in real time

### DIFF
--- a/desktop/src/renderer/hooks/useGraphSettings.ts
+++ b/desktop/src/renderer/hooks/useGraphSettings.ts
@@ -32,11 +32,13 @@ export function useGraphSettings(networkRef: React.MutableRefObject<any>) {
     setPhysics(next);
     if (!networkRef.current) return;
 
-    // Apply new physics options — keep physics enabled, don't call stabilize()
-    // The network will continuously simulate with the new parameters
+    // Update physics solver parameters and restart simulation.
+    // vis-network's setOptions() only calls init() internally — it does NOT
+    // restart a frozen simulation. We must call startSimulation() explicitly.
     networkRef.current.setOptions({
       physics: {
         enabled: true,
+        solver: 'forceAtlas2Based',
         forceAtlas2Based: {
           gravitationalConstant: next.gravitationalConstant,
           centralGravity: next.centralGravity,
@@ -47,9 +49,11 @@ export function useGraphSettings(networkRef: React.MutableRefObject<any>) {
         },
         maxVelocity: next.maxVelocity,
         timestep: next.timestep,
-        stabilization: false,
+        stabilization: { enabled: false },
       },
     });
+    // Kick the simulation alive — required after setOptions on a stopped network
+    networkRef.current.startSimulation();
   }, [networkRef]);
 
   const applyStyle = useCallback((next: GraphStyleSettings) => {

--- a/desktop/src/renderer/pages/KnowledgeGraph.tsx
+++ b/desktop/src/renderer/pages/KnowledgeGraph.tsx
@@ -104,6 +104,7 @@ function buildNetworkOptions(physics: typeof DEFAULT_PHYSICS, style: typeof DEFA
     },
     physics: {
       enabled: true,
+      solver: 'forceAtlas2Based',
       forceAtlas2Based: {
         gravitationalConstant: physics.gravitationalConstant,
         centralGravity: physics.centralGravity,


### PR DESCRIPTION
## Summary
- Added missing `solver: 'forceAtlas2Based'` declaration (was defaulting to barnesHut, ignoring all forceAtlas2 config)
- Fixed `stabilization: false` → `stabilization: { enabled: false }` (correct vis-network syntax)
- Added `network.startSimulation()` after `setOptions()` to restart frozen simulations

## Test plan
- [ ] Open Knowledge Graph, click Settings gear
- [ ] Drag Spring Length slider — nodes should spread/contract in real time
- [ ] Drag Gravitational Constant slider — repulsion changes visibly
- [ ] Close settings panel — physics freezes after ~2s settle

🤖 Generated with [Claude Code](https://claude.com/claude-code)